### PR TITLE
✨ Feature: Entity/Model 정의 및 데이터베이스 연결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,59 +1,55 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.1.5'
-	id 'io.spring.dependency-management' version '1.1.3'
+    id 'java'
+    id 'org.springframework.boot' version '3.1.5'
+    id 'io.spring.dependency-management' version '1.1.3'
 }
 
 group = 'com.wanted'
 version = '1.0.0'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	// Spring Web
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+    // Spring Web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	// Spring Data JPA
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // Spring Data JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-	// Flyway Migration
-	implementation 'org.flywaydb:flyway-core'
-	implementation 'org.flywaydb:flyway-mysql'
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
 
-	// Lombok
-	compileOnly 'org.projectlombok:lombok'
+    // Spring Boot DevTools
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
-	// Spring Boot DevTools
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    // H2 Database
+    runtimeOnly 'com.h2database:h2'
 
-	// H2 Database
-	runtimeOnly 'com.h2database:h2'
+    // MySQL Driver
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-	// MySQL Driver
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    // Lombok
+    annotationProcessor 'org.projectlombok:lombok'
 
-	// Lombok
-	annotationProcessor 'org.projectlombok:lombok'
-
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('bootBuildImage') {
-	builder = 'paketobuildpacks/builder-jammy-base:latest'
+    builder = 'paketobuildpacks/builder-jammy-base:latest'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/wanted/jaringoby/category/models/Category.java
+++ b/src/main/java/com/wanted/jaringoby/category/models/Category.java
@@ -1,0 +1,15 @@
+package com.wanted.jaringoby.category.models;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public enum Category {
+    Meal("Meal"),
+    Transportation("Transportation"),
+    Leisure("Leisure"),
+    Living("Living"),
+    PersonalDevelopment("PersonalDevelopment");
+
+    private final String name;
+}

--- a/src/main/java/com/wanted/jaringoby/common/converters/MoneyConverter.java
+++ b/src/main/java/com/wanted/jaringoby/common/converters/MoneyConverter.java
@@ -1,0 +1,19 @@
+package com.wanted.jaringoby.common.converters;
+
+import com.wanted.jaringoby.common.models.Money;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class MoneyConverter implements AttributeConverter<Money, Long> {
+
+    @Override
+    public Long convertToDatabaseColumn(Money money) {
+        return money.value();
+    }
+
+    @Override
+    public Money convertToEntityAttribute(Long value) {
+        return Money.of(value);
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/common/models/Money.java
+++ b/src/main/java/com/wanted/jaringoby/common/models/Money.java
@@ -1,0 +1,20 @@
+package com.wanted.jaringoby.common.models;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class Money {
+
+    private final Long value;
+
+    public static Money of(Long value) {
+        return new Money(value);
+    }
+
+    public Long value() {
+        return value;
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/customer/models/customer/Customer.java
+++ b/src/main/java/com/wanted/jaringoby/customer/models/customer/Customer.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;

--- a/src/main/java/com/wanted/jaringoby/customer/models/customer/Customer.java
+++ b/src/main/java/com/wanted/jaringoby/customer/models/customer/Customer.java
@@ -1,0 +1,35 @@
+package com.wanted.jaringoby.customer.models.customer;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "customers")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Customer {
+
+    @EmbeddedId
+    private CustomerId id;
+
+    @Embedded
+    private CustomerAccount account;
+
+    @Embedded
+    private CustomerPushConfiguration pushConfiguration;
+
+    @Column(updatable = false)
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/wanted/jaringoby/customer/models/customer/CustomerAccount.java
+++ b/src/main/java/com/wanted/jaringoby/customer/models/customer/CustomerAccount.java
@@ -3,13 +3,11 @@ package com.wanted.jaringoby.customer.models.customer;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class CustomerAccount {
 

--- a/src/main/java/com/wanted/jaringoby/customer/models/customer/CustomerAccount.java
+++ b/src/main/java/com/wanted/jaringoby/customer/models/customer/CustomerAccount.java
@@ -1,0 +1,21 @@
+package com.wanted.jaringoby.customer.models.customer;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class CustomerAccount {
+
+    @Column(name = "username")
+    private String username;
+
+    @Column(name = "password")
+    private String encodedPassword;
+}

--- a/src/main/java/com/wanted/jaringoby/customer/models/customer/CustomerId.java
+++ b/src/main/java/com/wanted/jaringoby/customer/models/customer/CustomerId.java
@@ -4,13 +4,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.io.Serializable;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class CustomerId implements Serializable {
 

--- a/src/main/java/com/wanted/jaringoby/customer/models/customer/CustomerId.java
+++ b/src/main/java/com/wanted/jaringoby/customer/models/customer/CustomerId.java
@@ -1,0 +1,19 @@
+package com.wanted.jaringoby.customer.models.customer;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class CustomerId implements Serializable {
+
+    @Column(name = "id")
+    private String value;
+}

--- a/src/main/java/com/wanted/jaringoby/customer/models/customer/CustomerPushConfiguration.java
+++ b/src/main/java/com/wanted/jaringoby/customer/models/customer/CustomerPushConfiguration.java
@@ -3,13 +3,11 @@ package com.wanted.jaringoby.customer.models.customer;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class CustomerPushConfiguration {
 

--- a/src/main/java/com/wanted/jaringoby/customer/models/customer/CustomerPushConfiguration.java
+++ b/src/main/java/com/wanted/jaringoby/customer/models/customer/CustomerPushConfiguration.java
@@ -1,0 +1,21 @@
+package com.wanted.jaringoby.customer.models.customer;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class CustomerPushConfiguration {
+
+    @Column(name = "daily_expense_recommendation_push_approved")
+    private Boolean dailyExpenseRecommendation;
+
+    @Column(name = "daily_expense_analysis_push_approved")
+    private Boolean dailyExpenseAnalysis;
+}

--- a/src/main/java/com/wanted/jaringoby/customer/repositories/CustomerRepository.java
+++ b/src/main/java/com/wanted/jaringoby/customer/repositories/CustomerRepository.java
@@ -1,0 +1,9 @@
+package com.wanted.jaringoby.customer.repositories;
+
+import com.wanted.jaringoby.customer.models.customer.Customer;
+import com.wanted.jaringoby.customer.models.customer.CustomerId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomerRepository extends JpaRepository<Customer, CustomerId> {
+
+}

--- a/src/main/java/com/wanted/jaringoby/expense/models/Expense.java
+++ b/src/main/java/com/wanted/jaringoby/expense/models/Expense.java
@@ -16,7 +16,6 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 

--- a/src/main/java/com/wanted/jaringoby/expense/models/Expense.java
+++ b/src/main/java/com/wanted/jaringoby/expense/models/Expense.java
@@ -1,0 +1,58 @@
+package com.wanted.jaringoby.expense.models;
+
+import com.wanted.jaringoby.category.models.Category;
+import com.wanted.jaringoby.common.converters.MoneyConverter;
+import com.wanted.jaringoby.common.models.Money;
+import com.wanted.jaringoby.customer.models.customer.CustomerId;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "expenses")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Expense {
+
+    @EmbeddedId
+    private ExpenseId id;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "customer_id"))
+    private CustomerId customerId;
+
+    @Column(name = "spent_at")
+    private LocalDateTime spentAt;
+
+    @Column(name = "category")
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    @Convert(converter = MoneyConverter.class)
+    @AttributeOverride(name = "value", column = @Column(name = "amount"))
+    private Money amount;
+
+    @Embedded
+    private ExpenseMemo memo;
+
+    @Embedded
+    private ExpenseProperty property;
+
+    @Column(updatable = false)
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/wanted/jaringoby/expense/models/ExpenseId.java
+++ b/src/main/java/com/wanted/jaringoby/expense/models/ExpenseId.java
@@ -1,0 +1,19 @@
+package com.wanted.jaringoby.expense.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class ExpenseId implements Serializable {
+
+    @Column(name = "id")
+    private String value;
+}

--- a/src/main/java/com/wanted/jaringoby/expense/models/ExpenseId.java
+++ b/src/main/java/com/wanted/jaringoby/expense/models/ExpenseId.java
@@ -4,13 +4,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.io.Serializable;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class ExpenseId implements Serializable {
 

--- a/src/main/java/com/wanted/jaringoby/expense/models/ExpenseMemo.java
+++ b/src/main/java/com/wanted/jaringoby/expense/models/ExpenseMemo.java
@@ -3,13 +3,11 @@ package com.wanted.jaringoby.expense.models;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class ExpenseMemo {
 

--- a/src/main/java/com/wanted/jaringoby/expense/models/ExpenseMemo.java
+++ b/src/main/java/com/wanted/jaringoby/expense/models/ExpenseMemo.java
@@ -1,0 +1,18 @@
+package com.wanted.jaringoby.expense.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class ExpenseMemo {
+
+    @Column(name = "memo")
+    private String value;
+}

--- a/src/main/java/com/wanted/jaringoby/expense/models/ExpenseProperty.java
+++ b/src/main/java/com/wanted/jaringoby/expense/models/ExpenseProperty.java
@@ -3,13 +3,11 @@ package com.wanted.jaringoby.expense.models;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class ExpenseProperty {
 

--- a/src/main/java/com/wanted/jaringoby/expense/models/ExpenseProperty.java
+++ b/src/main/java/com/wanted/jaringoby/expense/models/ExpenseProperty.java
@@ -1,0 +1,18 @@
+package com.wanted.jaringoby.expense.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class ExpenseProperty {
+
+    @Column(name = "included_expense_sum")
+    private Boolean includedExpenseSum;
+}

--- a/src/main/java/com/wanted/jaringoby/expense/repositories/ExpenseRepository.java
+++ b/src/main/java/com/wanted/jaringoby/expense/repositories/ExpenseRepository.java
@@ -1,0 +1,9 @@
+package com.wanted.jaringoby.expense.repositories;
+
+import com.wanted.jaringoby.expense.models.Expense;
+import com.wanted.jaringoby.expense.models.ExpenseId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExpenseRepository extends JpaRepository<Expense, ExpenseId> {
+
+}

--- a/src/main/java/com/wanted/jaringoby/ledger/models/budget/Budget.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/models/budget/Budget.java
@@ -1,0 +1,49 @@
+package com.wanted.jaringoby.ledger.models.budget;
+
+import com.wanted.jaringoby.category.models.Category;
+import com.wanted.jaringoby.common.models.Money;
+import com.wanted.jaringoby.common.converters.MoneyConverter;
+import com.wanted.jaringoby.ledger.models.ledger.LedgerId;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "budgets")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Budget {
+
+    @EmbeddedId
+    private BudgetId id;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "ledger_id"))
+    private LedgerId ledgerId;
+
+    @Column(name = "category")
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    @Convert(converter = MoneyConverter.class)
+    @AttributeOverride(name = "value", column = @Column(name = "amount"))
+    private Money amount;
+
+    @Column(updatable = false)
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/wanted/jaringoby/ledger/models/budget/Budget.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/models/budget/Budget.java
@@ -1,8 +1,8 @@
 package com.wanted.jaringoby.ledger.models.budget;
 
 import com.wanted.jaringoby.category.models.Category;
-import com.wanted.jaringoby.common.models.Money;
 import com.wanted.jaringoby.common.converters.MoneyConverter;
+import com.wanted.jaringoby.common.models.Money;
 import com.wanted.jaringoby.ledger.models.ledger.LedgerId;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
@@ -16,7 +16,6 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 

--- a/src/main/java/com/wanted/jaringoby/ledger/models/budget/BudgetId.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/models/budget/BudgetId.java
@@ -4,13 +4,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.io.Serializable;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class BudgetId implements Serializable {
 

--- a/src/main/java/com/wanted/jaringoby/ledger/models/budget/BudgetId.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/models/budget/BudgetId.java
@@ -1,0 +1,19 @@
+package com.wanted.jaringoby.ledger.models.budget;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class BudgetId implements Serializable {
+
+    @Column(name = "id")
+    private String value;
+}

--- a/src/main/java/com/wanted/jaringoby/ledger/models/ledger/Ledger.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/models/ledger/Ledger.java
@@ -1,0 +1,38 @@
+package com.wanted.jaringoby.ledger.models.ledger;
+
+import com.wanted.jaringoby.customer.models.customer.CustomerId;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "ledgers")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Ledger {
+
+    @EmbeddedId
+    private LedgerId id;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "customer_id"))
+    private CustomerId customerId;
+
+    @Embedded
+    private LedgerPeriod period;
+
+    @Column(updatable = false)
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/wanted/jaringoby/ledger/models/ledger/Ledger.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/models/ledger/Ledger.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;

--- a/src/main/java/com/wanted/jaringoby/ledger/models/ledger/LedgerId.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/models/ledger/LedgerId.java
@@ -1,0 +1,19 @@
+package com.wanted.jaringoby.ledger.models.ledger;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class LedgerId implements Serializable {
+
+    @Column(name = "id")
+    private String value;
+}

--- a/src/main/java/com/wanted/jaringoby/ledger/models/ledger/LedgerId.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/models/ledger/LedgerId.java
@@ -4,13 +4,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.io.Serializable;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class LedgerId implements Serializable {
 

--- a/src/main/java/com/wanted/jaringoby/ledger/models/ledger/LedgerPeriod.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/models/ledger/LedgerPeriod.java
@@ -4,13 +4,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.time.LocalDate;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class LedgerPeriod {
 

--- a/src/main/java/com/wanted/jaringoby/ledger/models/ledger/LedgerPeriod.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/models/ledger/LedgerPeriod.java
@@ -1,0 +1,22 @@
+package com.wanted.jaringoby.ledger.models.ledger;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class LedgerPeriod {
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+}

--- a/src/main/java/com/wanted/jaringoby/ledger/repositories/BudgetRepository.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/repositories/BudgetRepository.java
@@ -1,0 +1,9 @@
+package com.wanted.jaringoby.ledger.repositories;
+
+import com.wanted.jaringoby.ledger.models.budget.Budget;
+import com.wanted.jaringoby.ledger.models.budget.BudgetId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BudgetRepository extends JpaRepository<Budget, BudgetId> {
+
+}

--- a/src/main/java/com/wanted/jaringoby/ledger/repositories/LedgerRepository.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/repositories/LedgerRepository.java
@@ -1,0 +1,9 @@
+package com.wanted.jaringoby.ledger.repositories;
+
+import com.wanted.jaringoby.ledger.models.ledger.Ledger;
+import com.wanted.jaringoby.ledger.models.ledger.LedgerId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LedgerRepository extends JpaRepository<Ledger, LedgerId> {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,2 +1,24 @@
 server:
   port: 8000
+
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/wanted
+    username: root
+    password: root-password
+  jpa:
+    hibernate:
+      ddl-auto: none
+
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test
+  jpa:
+    hibernate:
+      ddl-auto: update

--- a/src/test/java/com/wanted/jaringoby/JaringobyApplicationTests.java
+++ b/src/test/java/com/wanted/jaringoby/JaringobyApplicationTests.java
@@ -2,12 +2,13 @@ package com.wanted.jaringoby;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class JaringobyApplicationTests {
 
     @Test
     void contextLoads() {
     }
-
 }


### PR DESCRIPTION
## 💻 작업 내역

- Domain Model 설계, ERD 설계를 바탕으로 Entity를 정의하고 데이터베이스 연결

## 🔎 PR 특이 사항

### 식별자 형식 선정

- 식별자로 사용할 수 있는 값으로 자동 증가 BIGINT, UUID, ULID의 사용을 고려하였으며, ULID를 사용하는 것으로 결정.
  - 자동 증가 BIGINT 타입의 식별자는 추측하기 쉬워 무차별 암호 대입과 같은 Brute Force 유형의 공격에 취약하다는 문제가 있음
  - UUID는 표준화된 형식에 따라 임의의 문자열을 생성하므로 무차별 대입을 통한 식별이 어려우면서도 서로 다른 시점에 생성된 UUID가 동일할 확률이 사실상 0에 수렴하므로 안전하나, 정수보다 광범위한 저장공간을 필요로 하고, UUID 간의 순서가 존재하지 않아 정렬을 고려할 수 없다는 단점이 있음
  - ULID는 26자 문자열에 밀리초 단위의 정밀도를 제공하는 10자의 타임스탬프 문자열을 포함해 식별자를 구성. 따라서 서로 다른 시점에 생성되는 ULID들이 같을 확률이 UUID와 마찬가지로 0에 수렴하면서도, 정렬이 가능하므로 추후 데이터베이스 파티셔닝이나 인덱싱 적용 시 효율적일 수 있음.
- Reference
  - [IDs: Integer Vs UUID Vs ULID](https://www.solwey.com/posts/ids-integer-vs-uuid-vs-ulid)
  - [ulid/spec](https://github.com/ulid/spec)
  - [ulid-creator](https://github.com/f4b6a3/ulid-creator)
  - [sulky-ulid](https://github.com/huxi/sulky/tree/master/sulky-ulid)