### PR TITLE
✨ Feature: 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     // Bouncy Castle Provider
     implementation 'org.bouncycastle:bcprov-jdk18on:1.76'
 
+    // Auth0 JWT
+    implementation 'com.auth0:java-jwt:4.4.0'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,12 @@ dependencies {
     // Spring Data JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
 

--- a/src/main/java/com/wanted/jaringoby/common/config/jpa/JpaConfig.java
+++ b/src/main/java/com/wanted/jaringoby/common/config/jpa/JpaConfig.java
@@ -1,0 +1,19 @@
+package com.wanted.jaringoby.common.config.jpa;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/common/config/jwt/JwtConfig.java
+++ b/src/main/java/com/wanted/jaringoby/common/config/jwt/JwtConfig.java
@@ -1,0 +1,28 @@
+package com.wanted.jaringoby.common.config.jwt;
+
+import com.auth0.jwt.algorithms.Algorithm;
+import com.wanted.jaringoby.common.utils.JwtUtil;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JwtConfig {
+
+    @Value("${jwt.secret}")
+    private String SECRET;
+
+    @Value("${jwt.valid-time.access-token}")
+    private Long VALID_TIME_ACCESS_TOKEN;
+
+    @Value("${jwt.valid-time.access-token}")
+    private Long VALID_TIME_REFRESH_TOKEN;
+
+    @Bean
+    public JwtUtil jwtUtil() {
+        return new JwtUtil(
+                Algorithm.HMAC256(SECRET),
+                VALID_TIME_ACCESS_TOKEN, VALID_TIME_REFRESH_TOKEN
+        );
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/common/config/jwt/JwtConfig.java
+++ b/src/main/java/com/wanted/jaringoby/common/config/jwt/JwtConfig.java
@@ -9,20 +9,25 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class JwtConfig {
 
-    @Value("${jwt.secret}")
-    private String SECRET;
+    private final String secret;
+    private final Long validTimeAccessToken;
+    private final Long validTimeRefreshToken;
 
-    @Value("${jwt.valid-time.access-token}")
-    private Long VALID_TIME_ACCESS_TOKEN;
-
-    @Value("${jwt.valid-time.access-token}")
-    private Long VALID_TIME_REFRESH_TOKEN;
+    public JwtConfig(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.valid-time.access-token}") Long validTimeAccessToken,
+            @Value("${jwt.valid-time.refresh-token}") Long validTimeRefreshToken
+    ) {
+        this.secret = secret;
+        this.validTimeAccessToken = validTimeAccessToken;
+        this.validTimeRefreshToken = validTimeRefreshToken;
+    }
 
     @Bean
     public JwtUtil jwtUtil() {
         return new JwtUtil(
-                Algorithm.HMAC256(SECRET),
-                VALID_TIME_ACCESS_TOKEN, VALID_TIME_REFRESH_TOKEN
+                Algorithm.HMAC256(secret),
+                validTimeAccessToken, validTimeRefreshToken
         );
     }
 }

--- a/src/main/java/com/wanted/jaringoby/common/utils/JwtUtil.java
+++ b/src/main/java/com/wanted/jaringoby/common/utils/JwtUtil.java
@@ -1,0 +1,41 @@
+package com.wanted.jaringoby.common.utils;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.wanted.jaringoby.customer.models.customer.Customer;
+import com.wanted.jaringoby.customer.models.customer.CustomerId;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    private static final String CLAIM_TYPE = "type";
+    private static final String CLAIM_CUSTOMER_ID = "customerId";
+
+    private final Algorithm algorithm;
+    private final Long validTimeAccessToken;
+    private final Long validTimeRefreshToken;
+
+    public String issueAccessToken(Customer customer) {
+        Date now = new Date();
+        Date expiresAt = new Date(now.getTime() + validTimeAccessToken);
+
+        return JWT.create()
+                .withClaim(CLAIM_TYPE, "accessToken")
+                .withClaim(CLAIM_CUSTOMER_ID, customer.id().value())
+                .withExpiresAt(expiresAt)
+                .sign(algorithm);
+    }
+
+    public String issueRefreshToken(CustomerId customerId) {
+        Date now = new Date();
+        Date expiresAt = new Date(now.getTime() + validTimeRefreshToken);
+
+        return JWT.create()
+                .withClaim(CLAIM_TYPE, "refreshToken")
+                .withClaim(CLAIM_CUSTOMER_ID, customerId.value())
+                .withExpiresAt(expiresAt)
+                .sign(algorithm);
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/common/utils/JwtUtil.java
+++ b/src/main/java/com/wanted/jaringoby/common/utils/JwtUtil.java
@@ -2,7 +2,6 @@ package com.wanted.jaringoby.common.utils;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
-import com.wanted.jaringoby.customer.models.customer.Customer;
 import com.wanted.jaringoby.customer.models.customer.CustomerId;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
@@ -17,13 +16,13 @@ public class JwtUtil {
     private final Long validTimeAccessToken;
     private final Long validTimeRefreshToken;
 
-    public String issueAccessToken(Customer customer) {
+    public String issueAccessToken(CustomerId customerId) {
         Date now = new Date();
         Date expiresAt = new Date(now.getTime() + validTimeAccessToken);
 
         return JWT.create()
                 .withClaim(CLAIM_TYPE, "accessToken")
-                .withClaim(CLAIM_CUSTOMER_ID, customer.id().value())
+                .withClaim(CLAIM_CUSTOMER_ID, customerId.value())
                 .withExpiresAt(expiresAt)
                 .sign(algorithm);
     }

--- a/src/main/java/com/wanted/jaringoby/common/utils/UlidGenerator.java
+++ b/src/main/java/com/wanted/jaringoby/common/utils/UlidGenerator.java
@@ -3,9 +3,14 @@ package com.wanted.jaringoby.common.utils;
 import de.huxhorn.sulky.ulid.ULID;
 
 public class UlidGenerator {
+
     private final ULID ulid = new ULID();
 
-    public String createRandomULID() {
-        return ulid.nextULID();
+    public String createRandomCustomerULID() {
+        return "CUSTOMER_" + ulid.nextULID();
+    }
+
+    public String createRandomCustomerRefreshTokenULID() {
+        return "CUSTOMER_REFRESH_TOKEN_" + ulid.nextULID();
     }
 }

--- a/src/main/java/com/wanted/jaringoby/customer/applications/CreateCustomerService.java
+++ b/src/main/java/com/wanted/jaringoby/customer/applications/CreateCustomerService.java
@@ -33,10 +33,10 @@ public class CreateCustomerService {
         validateReconfirmPassword(password, reconfirmPassword);
 
         Customer customer = Customer.builder()
+                .id(ulidGenerator.createRandomCustomerULID())
                 .username(username)
                 .build();
 
-        customer.generateId(ulidGenerator);
         customer.changePassword(password, passwordEncoder);
 
         customerRepository.save(customer);

--- a/src/main/java/com/wanted/jaringoby/customer/exceptions/CustomerNotFoundException.java
+++ b/src/main/java/com/wanted/jaringoby/customer/exceptions/CustomerNotFoundException.java
@@ -1,0 +1,11 @@
+package com.wanted.jaringoby.customer.exceptions;
+
+import com.wanted.jaringoby.common.exceptions.CustomizedException;
+import org.springframework.http.HttpStatus;
+
+public class CustomerNotFoundException extends CustomizedException {
+
+    public CustomerNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "존재하지 않는 고객입니다.");
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/customer/exceptions/CustomerPasswordMismatchedException.java
+++ b/src/main/java/com/wanted/jaringoby/customer/exceptions/CustomerPasswordMismatchedException.java
@@ -1,0 +1,11 @@
+package com.wanted.jaringoby.customer.exceptions;
+
+import com.wanted.jaringoby.common.exceptions.CustomizedException;
+import org.springframework.http.HttpStatus;
+
+public class CustomerPasswordMismatchedException extends CustomizedException {
+
+    public CustomerPasswordMismatchedException() {
+        super(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/customer/models/customer/Customer.java
+++ b/src/main/java/com/wanted/jaringoby/customer/models/customer/Customer.java
@@ -1,6 +1,5 @@
 package com.wanted.jaringoby.customer.models.customer;
 
-import com.wanted.jaringoby.common.utils.UlidGenerator;
 import com.wanted.jaringoby.customer.dtos.CreateCustomerResponseDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -37,17 +36,22 @@ public class Customer {
     private LocalDateTime updatedAt;
 
     @Builder
-    public Customer(String username) {
+    public Customer(String id, String username) {
+        this.id = CustomerId.of(id);
         this.account = CustomerAccount.ofUsername(username);
         this.pushConfiguration = CustomerPushConfiguration.defaultStatus();
     }
 
-    public void generateId(UlidGenerator ulidGenerator) {
-        this.id = CustomerId.generate(ulidGenerator);
+    public CustomerId id() {
+        return id;
     }
 
     public void changePassword(String password, PasswordEncoder passwordEncoder) {
         this.account.changePassword(password, passwordEncoder);
+    }
+
+    public boolean passwordMatches(String password, PasswordEncoder passwordEncoder) {
+        return account.passwordMatches(password, passwordEncoder);
     }
 
     public CreateCustomerResponseDto toCreationResponseDto() {

--- a/src/main/java/com/wanted/jaringoby/customer/models/customer/CustomerAccount.java
+++ b/src/main/java/com/wanted/jaringoby/customer/models/customer/CustomerAccount.java
@@ -29,4 +29,8 @@ public class CustomerAccount {
     public void changePassword(String password, PasswordEncoder passwordEncoder) {
         this.encodedPassword = passwordEncoder.encode(password);
     }
+
+    public boolean passwordMatches(String password, PasswordEncoder passwordEncoder) {
+        return passwordEncoder.matches(password, encodedPassword);
+    }
 }

--- a/src/main/java/com/wanted/jaringoby/customer/models/customer/CustomerId.java
+++ b/src/main/java/com/wanted/jaringoby/customer/models/customer/CustomerId.java
@@ -1,6 +1,5 @@
 package com.wanted.jaringoby.customer.models.customer;
 
-import com.wanted.jaringoby.common.utils.UlidGenerator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.io.Serializable;
@@ -18,8 +17,8 @@ public class CustomerId implements Serializable {
     @Column(name = "id")
     private String value;
 
-    public static CustomerId generate(UlidGenerator ulidGenerator) {
-        return new CustomerId("CUSTOMER_" + ulidGenerator.createRandomULID());
+    public static CustomerId of(String value) {
+        return new CustomerId(value);
     }
 
     public String value() {

--- a/src/main/java/com/wanted/jaringoby/customer/repositories/CustomerRepository.java
+++ b/src/main/java/com/wanted/jaringoby/customer/repositories/CustomerRepository.java
@@ -2,9 +2,12 @@ package com.wanted.jaringoby.customer.repositories;
 
 import com.wanted.jaringoby.customer.models.customer.Customer;
 import com.wanted.jaringoby.customer.models.customer.CustomerId;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CustomerRepository extends JpaRepository<Customer, CustomerId> {
 
     boolean existsByAccountUsername(String username);
+
+    Optional<Customer> findByAccountUsername(String username);
 }

--- a/src/main/java/com/wanted/jaringoby/session/applications/LoginService.java
+++ b/src/main/java/com/wanted/jaringoby/session/applications/LoginService.java
@@ -1,0 +1,15 @@
+package com.wanted.jaringoby.session.applications;
+
+import com.wanted.jaringoby.session.dtos.LoginRequestDto;
+import com.wanted.jaringoby.session.dtos.LoginResponseDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class LoginService {
+
+    @Transactional
+    public LoginResponseDto login(LoginRequestDto loginRequestDto) {
+        return null;
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/session/applications/LoginService.java
+++ b/src/main/java/com/wanted/jaringoby/session/applications/LoginService.java
@@ -1,15 +1,102 @@
 package com.wanted.jaringoby.session.applications;
 
+import com.wanted.jaringoby.common.utils.JwtUtil;
+import com.wanted.jaringoby.common.utils.UlidGenerator;
+import com.wanted.jaringoby.customer.exceptions.CustomerNotFoundException;
+import com.wanted.jaringoby.customer.exceptions.CustomerPasswordMismatchedException;
+import com.wanted.jaringoby.customer.models.customer.Customer;
+import com.wanted.jaringoby.customer.repositories.CustomerRepository;
 import com.wanted.jaringoby.session.dtos.LoginRequestDto;
 import com.wanted.jaringoby.session.dtos.LoginResponseDto;
+import com.wanted.jaringoby.session.entities.CustomerRefreshToken;
+import com.wanted.jaringoby.session.repositories.CustomerRefreshTokenRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class LoginService {
 
-    @Transactional
+    private final CustomerRepository customerRepository;
+    private final CustomerRefreshTokenRepository customerRefreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final UlidGenerator ulidGenerator;
+    private final JwtUtil jwtUtil;
+
+    private final Long maxSessionsCount;
+
+    public LoginService(
+            CustomerRepository customerRepository,
+            CustomerRefreshTokenRepository customerRefreshTokenRepository,
+            PasswordEncoder passwordEncoder,
+            UlidGenerator ulidGenerator,
+            JwtUtil jwtUtil,
+            @Value("${session.max-count}") Long maxSessionsCount
+    ) {
+        this.customerRepository = customerRepository;
+        this.customerRefreshTokenRepository = customerRefreshTokenRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.ulidGenerator = ulidGenerator;
+        this.jwtUtil = jwtUtil;
+        this.maxSessionsCount = maxSessionsCount;
+    }
+
     public LoginResponseDto login(LoginRequestDto loginRequestDto) {
-        return null;
+        String username = loginRequestDto.getUsername();
+        String password = loginRequestDto.getPassword();
+
+        Customer customer = validateUsername(username);
+
+        validatePassword(password, customer);
+
+        // TODO: 이벤트 발행 방식 비동기 처리시키기
+        if (exceededMaxSessionCount(customer)) {
+            destroyOldestRequestedSession(customer);
+        }
+
+        return LoginResponseDto.builder()
+                .accessToken(issueAccessToken(customer))
+                .refreshToken(issueRefreshToken(customer))
+                .build();
+    }
+
+    private Customer validateUsername(String username) {
+        return customerRepository
+                .findByAccountUsername(username)
+                .orElseThrow(CustomerNotFoundException::new);
+    }
+
+    private void validatePassword(String password, Customer customer) {
+        if (!customer.passwordMatches(password, passwordEncoder)) {
+            throw new CustomerPasswordMismatchedException();
+        }
+    }
+
+    private boolean exceededMaxSessionCount(Customer customer) {
+        return customerRefreshTokenRepository
+                .countByCustomerId(customer.id()) >= maxSessionsCount;
+    }
+
+    private void destroyOldestRequestedSession(Customer customer) {
+        customerRefreshTokenRepository
+                .deleteByCustomerIdAndOldestRequestedAt(customer.id());
+    }
+
+    private String issueAccessToken(Customer customer) {
+        return jwtUtil.issueAccessToken(customer.id());
+    }
+
+    private String issueRefreshToken(Customer customer) {
+        CustomerRefreshToken customerRefreshToken = CustomerRefreshToken.builder()
+                .id(ulidGenerator.createRandomCustomerRefreshTokenULID())
+                .customer(customer)
+                .build();
+        customerRefreshToken.issue(jwtUtil);
+
+        customerRefreshTokenRepository.save(customerRefreshToken);
+
+        return customerRefreshToken.value();
     }
 }

--- a/src/main/java/com/wanted/jaringoby/session/controllers/SessionController.java
+++ b/src/main/java/com/wanted/jaringoby/session/controllers/SessionController.java
@@ -1,0 +1,37 @@
+package com.wanted.jaringoby.session.controllers;
+
+import com.wanted.jaringoby.common.response.Response;
+import com.wanted.jaringoby.common.validations.BindingResultChecker;
+import com.wanted.jaringoby.common.validations.ValidationSequence;
+import com.wanted.jaringoby.session.applications.LoginService;
+import com.wanted.jaringoby.session.dtos.LoginRequestDto;
+import com.wanted.jaringoby.session.dtos.LoginResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/customer/v1.0/sessions")
+@RequiredArgsConstructor
+public class SessionController {
+
+    private final LoginService loginService;
+    private final BindingResultChecker bindingResultChecker;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Response<LoginResponseDto> login(
+            @Validated(ValidationSequence.class) @RequestBody LoginRequestDto loginRequestDto,
+            BindingResult bindingResult
+    ) {
+        bindingResultChecker.checkBindingErrors(bindingResult);
+
+        return Response.of(loginService.login(loginRequestDto));
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/session/dtos/LoginRequestDto.java
+++ b/src/main/java/com/wanted/jaringoby/session/dtos/LoginRequestDto.java
@@ -1,0 +1,22 @@
+package com.wanted.jaringoby.session.dtos;
+
+import com.wanted.jaringoby.common.validations.groups.MissingValueGroup;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+@Getter
+public class LoginRequestDto {
+
+    @NotBlank(groups = MissingValueGroup.class)
+    private String username;
+
+    @NotBlank(groups = MissingValueGroup.class)
+    private String password;
+}

--- a/src/main/java/com/wanted/jaringoby/session/dtos/LoginResponseDto.java
+++ b/src/main/java/com/wanted/jaringoby/session/dtos/LoginResponseDto.java
@@ -1,0 +1,11 @@
+package com.wanted.jaringoby.session.dtos;
+
+import lombok.Builder;
+
+@Builder
+public record LoginResponseDto(
+        String accessToken,
+        String refreshToken
+) {
+
+}

--- a/src/main/java/com/wanted/jaringoby/session/entities/CustomerRefreshToken.java
+++ b/src/main/java/com/wanted/jaringoby/session/entities/CustomerRefreshToken.java
@@ -1,0 +1,53 @@
+package com.wanted.jaringoby.session.entities;
+
+import com.wanted.jaringoby.common.utils.JwtUtil;
+import com.wanted.jaringoby.customer.models.customer.Customer;
+import com.wanted.jaringoby.customer.models.customer.CustomerId;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "customer_refresh_tokens")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomerRefreshToken {
+
+    @EmbeddedId
+    private CustomerRefreshTokenId id;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "customer_id"))
+    private CustomerId customerId;
+
+    @Column(name = "token_value")
+    private String value;
+
+    @Column(name = "requested_at")
+    private LocalDateTime requestedAt;
+
+    @Builder
+    private CustomerRefreshToken(String id, Customer customer) {
+        this.id = CustomerRefreshTokenId.of(id);
+        this.customerId = customer.id();
+        this.requestedAt = LocalDateTime.now();
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public LocalDateTime requestedAt() {
+        return requestedAt;
+    }
+
+    public void issue(JwtUtil jwtUtil) {
+        value = jwtUtil.issueRefreshToken(customerId);
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/session/entities/CustomerRefreshTokenId.java
+++ b/src/main/java/com/wanted/jaringoby/session/entities/CustomerRefreshTokenId.java
@@ -1,0 +1,23 @@
+package com.wanted.jaringoby.session.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class CustomerRefreshTokenId implements Serializable {
+
+    @Column(name = "id")
+    private String value;
+
+    public static CustomerRefreshTokenId of(String value) {
+        return new CustomerRefreshTokenId(value);
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/session/repositories/CustomerRefreshTokenQueryDslRepository.java
+++ b/src/main/java/com/wanted/jaringoby/session/repositories/CustomerRefreshTokenQueryDslRepository.java
@@ -1,0 +1,8 @@
+package com.wanted.jaringoby.session.repositories;
+
+import com.wanted.jaringoby.customer.models.customer.CustomerId;
+
+public interface CustomerRefreshTokenQueryDslRepository {
+
+    void deleteByCustomerIdAndOldestRequestedAt(CustomerId customerId);
+}

--- a/src/main/java/com/wanted/jaringoby/session/repositories/CustomerRefreshTokenQueryDslRepositoryImpl.java
+++ b/src/main/java/com/wanted/jaringoby/session/repositories/CustomerRefreshTokenQueryDslRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.wanted.jaringoby.session.repositories;
+
+import static com.wanted.jaringoby.session.entities.QCustomerRefreshToken.customerRefreshToken;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wanted.jaringoby.customer.models.customer.CustomerId;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomerRefreshTokenQueryDslRepositoryImpl
+        implements CustomerRefreshTokenQueryDslRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public void deleteByCustomerIdAndOldestRequestedAt(CustomerId customerId) {
+        LocalDateTime oldestRequestedAt = jpaQueryFactory
+                .select(customerRefreshToken.requestedAt.min())
+                .from(customerRefreshToken)
+                .where(customerRefreshToken.customerId.eq(customerId))
+                .fetchOne();
+
+        jpaQueryFactory.delete(customerRefreshToken)
+                .where(customerRefreshToken.customerId.eq(customerId)
+                        .and(customerRefreshToken.requestedAt.eq(oldestRequestedAt)))
+                .execute();
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/session/repositories/CustomerRefreshTokenRepository.java
+++ b/src/main/java/com/wanted/jaringoby/session/repositories/CustomerRefreshTokenRepository.java
@@ -1,0 +1,16 @@
+package com.wanted.jaringoby.session.repositories;
+
+import com.wanted.jaringoby.customer.models.customer.CustomerId;
+import com.wanted.jaringoby.session.entities.CustomerRefreshToken;
+import com.wanted.jaringoby.session.entities.CustomerRefreshTokenId;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomerRefreshTokenRepository extends
+        JpaRepository<CustomerRefreshToken, CustomerRefreshTokenId>,
+        CustomerRefreshTokenQueryDslRepository {
+
+    Long countByCustomerId(CustomerId customerId);
+
+    Optional<CustomerRefreshToken> findByCustomerId(CustomerId customerId);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,9 @@ jwt:
     access-token: 120000
     refresh-token: 300000
 
+session:
+  max-count: 2
+
 ---
 spring:
   config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,12 @@ spring:
     hibernate:
       ddl-auto: none
 
+jwt:
+  secret: TEST
+  valid-time:
+    access-token: 120000
+    refresh-token: 300000
+
 ---
 spring:
   config:
@@ -22,3 +28,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+
+jwt:
+  secret: TEST
+  valid-time:
+    access-token: 2000
+    refresh-token: 5000

--- a/src/test/java/com/wanted/jaringoby/config/jpa/JpaTestConfig.java
+++ b/src/test/java/com/wanted/jaringoby/config/jpa/JpaTestConfig.java
@@ -1,0 +1,19 @@
+package com.wanted.jaringoby.config.jpa;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class JpaTestConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/com/wanted/jaringoby/customer/applications/CreateCustomerServiceTest.java
+++ b/src/test/java/com/wanted/jaringoby/customer/applications/CreateCustomerServiceTest.java
@@ -50,14 +50,14 @@ class CreateCustomerServiceTest {
     @Nested
     class Success {
 
-        private static final String ULID = "ULID";
+        private static final String ULID = "CUSTOMER_ULID";
 
         @DisplayName("Customer 생성 후 영속화, 생성된 Customer 식별자 반환")
         @Test
         void createCustomer() {
             given(customerRepository.existsByAccountUsername(USERNAME))
                     .willReturn(false);
-            given(ulidGenerator.createRandomULID()).willReturn(ULID);
+            given(ulidGenerator.createRandomCustomerULID()).willReturn(ULID);
 
             CreateCustomerRequestDto createCustomerRequestDto = CreateCustomerRequestDto.builder()
                     .username(USERNAME)
@@ -69,9 +69,9 @@ class CreateCustomerServiceTest {
                     .createCustomer(createCustomerRequestDto);
 
             assertThat(createCustomerResponseDto).isNotNull();
-            assertThat(createCustomerResponseDto.customerId()).isEqualTo("CUSTOMER_" + ULID);
+            assertThat(createCustomerResponseDto.customerId()).isEqualTo(ULID);
 
-            verify(ulidGenerator).createRandomULID();
+            verify(ulidGenerator).createRandomCustomerULID();
             verify(passwordEncoder).encode(PASSWORD);
             verify(customerRepository).save(any(Customer.class));
         }
@@ -99,7 +99,7 @@ class CreateCustomerServiceTest {
             assertThrows(CustomerUsernameDuplicatedException.class, () -> createCustomerService
                     .createCustomer(createCustomerRequestDto));
 
-            verify(ulidGenerator, never()).createRandomULID();
+            verify(ulidGenerator, never()).createRandomCustomerULID();
             verify(passwordEncoder, never()).encode(any(String.class));
             verify(customerRepository, never()).save(any(Customer.class));
         }
@@ -119,7 +119,7 @@ class CreateCustomerServiceTest {
             assertThrows(CustomerReconfirmPasswordMismatchedException.class,
                     () -> createCustomerService.createCustomer(createCustomerRequestDto));
 
-            verify(ulidGenerator, never()).createRandomULID();
+            verify(ulidGenerator, never()).createRandomCustomerULID();
             verify(passwordEncoder, never()).encode(any(String.class));
             verify(customerRepository, never()).save(any(Customer.class));
         }

--- a/src/test/java/com/wanted/jaringoby/session/applications/LoginServiceTest.java
+++ b/src/test/java/com/wanted/jaringoby/session/applications/LoginServiceTest.java
@@ -1,0 +1,178 @@
+package com.wanted.jaringoby.session.applications;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.wanted.jaringoby.common.utils.JwtUtil;
+import com.wanted.jaringoby.common.utils.UlidGenerator;
+import com.wanted.jaringoby.customer.exceptions.CustomerNotFoundException;
+import com.wanted.jaringoby.customer.exceptions.CustomerPasswordMismatchedException;
+import com.wanted.jaringoby.customer.models.customer.Customer;
+import com.wanted.jaringoby.customer.repositories.CustomerRepository;
+import com.wanted.jaringoby.session.dtos.LoginRequestDto;
+import com.wanted.jaringoby.session.dtos.LoginResponseDto;
+import com.wanted.jaringoby.session.entities.CustomerRefreshToken;
+import com.wanted.jaringoby.session.repositories.CustomerRefreshTokenRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+class LoginServiceTest {
+
+    private LoginService loginService;
+    private CustomerRepository customerRepository;
+    private CustomerRefreshTokenRepository customerRefreshTokenRepository;
+    private PasswordEncoder passwordEncoder;
+    private JwtUtil jwtUtil;
+    private UlidGenerator ulidGenerator;
+
+    private static final Long MAX_SESSIONS_COUNT = 2L;
+
+    @BeforeEach
+    void setUp() {
+        customerRepository = mock(CustomerRepository.class);
+        customerRefreshTokenRepository = mock(CustomerRefreshTokenRepository.class);
+        passwordEncoder = mock(Argon2PasswordEncoder.class);
+        ulidGenerator = mock(UlidGenerator.class);
+        jwtUtil = mock(JwtUtil.class);
+
+        loginService = new LoginService(
+                customerRepository,
+                customerRefreshTokenRepository,
+                passwordEncoder,
+                ulidGenerator,
+                jwtUtil,
+                MAX_SESSIONS_COUNT
+        );
+    }
+
+    private static final String CUSTOMER_ID = "CUSTOMER_1";
+    private static final String USERNAME = "hsjkdss228";
+    private static final String PASSWORD = "Password!1";
+
+    private final LoginRequestDto loginRequestDto = LoginRequestDto.builder()
+            .username(USERNAME)
+            .password(PASSWORD)
+            .build();
+
+    private final Customer customer = Customer.builder()
+            .id(CUSTOMER_ID)
+            .username(USERNAME)
+            .build();
+
+    private static final String CUSTOMER_REFRESH_TOKEN_ID = "CUSTOMER_REFRESH_TOKEN_ID_1";
+
+    private static final String ACCESS_TOKEN = "ACCESS_TOKEN";
+    private static final String REFRESH_TOKEN = "REFRESH_TOKEN";
+
+    @DisplayName("성공")
+    @Nested
+    class Success {
+
+        @BeforeEach
+        void setUp() {
+            given(customerRepository.findByAccountUsername(USERNAME))
+                    .willReturn(Optional.of(customer));
+
+            given(customer.passwordMatches(PASSWORD, passwordEncoder)).willReturn(true);
+
+            given(customerRefreshTokenRepository.countByCustomerId(customer.id()))
+                    .willReturn(0L);
+
+            given(ulidGenerator.createRandomCustomerRefreshTokenULID())
+                    .willReturn(CUSTOMER_REFRESH_TOKEN_ID);
+
+            given(jwtUtil.issueAccessToken(customer.id()))
+                    .willReturn(ACCESS_TOKEN);
+            given(jwtUtil.issueRefreshToken(customer.id()))
+                    .willReturn(REFRESH_TOKEN);
+        }
+
+        @DisplayName("액세스 토큰, 리프레시 토큰 발행 후 반환")
+        @Test
+        void login() {
+            LoginResponseDto loginResponseDto = loginService.login(loginRequestDto);
+
+            assertThat(loginResponseDto).isNotNull();
+            assertThat(loginResponseDto.accessToken()).isEqualTo(ACCESS_TOKEN);
+            assertThat(loginResponseDto.refreshToken()).isEqualTo(REFRESH_TOKEN);
+
+            verify(jwtUtil).issueAccessToken(customer.id());
+            verify(jwtUtil).issueRefreshToken(customer.id());
+            verify(customerRefreshTokenRepository).save(any(CustomerRefreshToken.class));
+        }
+
+        // TODO: 이벤트 발행 방식 비동기 처리로 리팩토링하고, 해당 테스트도 분리
+        @DisplayName("허용 세션 수 이내인 경우")
+        @Nested
+        class WithinMaxSessions {
+
+            @DisplayName("요청 시점이 가장 오래된 세션을 파기하지 않음")
+            @Test
+            void doNotDestroyOldestRequestedSession() {
+                given(customerRefreshTokenRepository.countByCustomerId(customer.id()))
+                        .willReturn(MAX_SESSIONS_COUNT - 1);
+
+                loginService.login(loginRequestDto);
+
+                verify(customerRefreshTokenRepository, never())
+                        .deleteByCustomerIdAndOldestRequestedAt(customer.id());
+            }
+        }
+
+        @DisplayName("허용 세션 수에 도달한 상태인 경우")
+        @Nested
+        class ReachedMaxSessions {
+
+            @DisplayName("요청 시점이 가장 오래된 세션을 파기")
+            @Test
+            void destroyOldestRequestedSession() {
+                given(customerRefreshTokenRepository.countByCustomerId(customer.id()))
+                        .willReturn(MAX_SESSIONS_COUNT);
+
+                loginService.login(loginRequestDto);
+
+                verify(customerRefreshTokenRepository)
+                        .deleteByCustomerIdAndOldestRequestedAt(customer.id());
+            }
+        }
+    }
+
+    @DisplayName("실패")
+    @Nested
+    class Failure {
+
+        @DisplayName("고객 계정이 존재하지 않는 경우 예외 발생")
+        @Test
+        void customerNotFound() {
+            given(customerRepository.findByAccountUsername(USERNAME))
+                    .willThrow(CustomerNotFoundException.class);
+
+            assertThrows(CustomerNotFoundException.class,
+                    () -> loginService.login(loginRequestDto));
+        }
+
+        @DisplayName("비밀번호가 일치하지 않는 경우 예외 발생")
+        @Test
+        void customerPasswordMismatches() {
+            given(customerRepository.findByAccountUsername(USERNAME))
+                    .willReturn(Optional.of(customer));
+
+            given(customer.passwordMatches(PASSWORD, passwordEncoder)).willReturn(false);
+
+            assertThrows(CustomerPasswordMismatchedException.class,
+                    () -> loginService.login(loginRequestDto));
+        }
+    }
+}

--- a/src/test/java/com/wanted/jaringoby/session/controllers/SessionControllerTest.java
+++ b/src/test/java/com/wanted/jaringoby/session/controllers/SessionControllerTest.java
@@ -1,0 +1,113 @@
+package com.wanted.jaringoby.session.controllers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.wanted.jaringoby.common.config.validation.ValidationConfig;
+import com.wanted.jaringoby.common.validations.BindingResultChecker;
+import com.wanted.jaringoby.session.applications.LoginService;
+import com.wanted.jaringoby.session.dtos.LoginRequestDto;
+import com.wanted.jaringoby.session.dtos.LoginResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(SessionController.class)
+@Import(ValidationConfig.class)
+class SessionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LoginService loginService;
+
+    @SpyBean
+    private BindingResultChecker bindingResultChecker;
+
+    @DisplayName("POST /customer/v1.0/sessions")
+    @Nested
+    class PostSessions {
+
+        @DisplayName("성공")
+        @Nested
+        class Success {
+
+            private static final String ACCESS_TOKEN = "ACCESS_TOKEN";
+            private static final String REFRESH_TOKEN = "REFRESH_TOKEN";
+
+            @DisplayName("생성된 accessToken, refreshToken 식별자를 응답으로 반환")
+            @Test
+            void create() throws Exception {
+                LoginResponseDto loginResponseDto = LoginResponseDto.builder()
+                        .accessToken(ACCESS_TOKEN)
+                        .refreshToken(REFRESH_TOKEN)
+                        .build();
+
+                given(loginService.login(any(LoginRequestDto.class)))
+                        .willReturn(loginResponseDto);
+
+                mockMvc.perform(post("/customer/v1.0/sessions")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "username": "hsjkdss228",
+                                            "password": "Password!1"
+                                        }
+                                        """))
+                        .andExpect(status().isCreated());
+            }
+        }
+
+        @DisplayName("실패")
+        @Nested
+        class Failure {
+
+            private void performAndExpectIsBadRequest(String content) throws Exception {
+                mockMvc.perform(post("/customer/v1.0/sessions")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .content(
+                                        content
+                                ))
+                        .andExpect(status().isBadRequest());
+
+                verify(loginService, never())
+                        .login(any(LoginRequestDto.class));
+            }
+
+            @DisplayName("username 미입력된 경우 예외처리")
+            @Test
+            void blankUsername() throws Exception {
+                performAndExpectIsBadRequest("""
+                        {
+                            "username": "  ",
+                            "password": "Password!1"
+                        }
+                        """);
+            }
+
+            @DisplayName("password 미입력된 경우 예외처리")
+            @Test
+            void blankPassword() throws Exception {
+                performAndExpectIsBadRequest("""
+                        {
+                            "username": "hsjkdss228"
+                        }
+                        """);
+            }
+        }
+    }
+}

--- a/src/test/java/com/wanted/jaringoby/session/repositories/CustomerRefreshTokenQueryDslRepositoryImplTest.java
+++ b/src/test/java/com/wanted/jaringoby/session/repositories/CustomerRefreshTokenQueryDslRepositoryImplTest.java
@@ -1,0 +1,82 @@
+package com.wanted.jaringoby.session.repositories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.wanted.jaringoby.config.jpa.JpaTestConfig;
+import com.wanted.jaringoby.customer.models.customer.Customer;
+import com.wanted.jaringoby.session.entities.CustomerRefreshToken;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(JpaTestConfig.class)
+@ActiveProfiles("test")
+class CustomerRefreshTokenQueryDslRepositoryImplTest {
+
+    @Autowired
+    private CustomerRefreshTokenQueryDslRepositoryImpl repositoryImpl;
+
+    @Autowired
+    private CustomerRefreshTokenRepository customerRefreshTokenRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    // TODO: Testcontainer를 활용해 실제 MySQL 환경의 데이터베이스에서 테스트 수행
+    //       작성한 쿼리문이 특정 데이터베이스에서 제한되는 형식인지도 확인할 수 있어야 함.
+
+    private static final LocalDateTime NOW = LocalDateTime.now();
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DELETE FROM customer_refresh_tokens");
+        jdbcTemplate.execute("DELETE FROM customers");
+
+        jdbcTemplate.update("""
+                        INSERT INTO customers(id, username, password,
+                        daily_expense_recommendation_push_approved,
+                        daily_expense_analysis_push_approved,
+                        created_at, updated_at)
+                        VALUES (?, ?, ?, ?, ?, ?, ?)
+                        """,
+                "CUSTOMER_1", "hsjkdss228", "Password!1", true, true,
+                NOW.minusHours(1), NOW.minusHours(1));
+
+        jdbcTemplate.update("""
+                        INSERT INTO customer_refresh_tokens(id, customer_id, token_value, requested_at)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                "CUSTOMER_REFRESH_TOKEN_1", "CUSTOMER_1", "REFRESH_TOKEN_1", NOW.minusMinutes(30));
+        jdbcTemplate.update("""
+                        INSERT INTO customer_refresh_tokens(id, customer_id, token_value, requested_at)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                "CUSTOMER_REFRESH_TOKEN_2", "CUSTOMER_1", "REFRESH_TOKEN_2", NOW.minusMinutes(15));
+    }
+
+    @DisplayName("requestedAt이 가장 이전 시간대인 CustomerRefreshToken을 데이터베이스에서 제거")
+    @Test
+    void deleteByCustomerIdAndOldestRequestedAt() {
+        Customer customer = Customer.builder()
+                .id("CUSTOMER_1")
+                .build();
+
+        repositoryImpl.deleteByCustomerIdAndOldestRequestedAt(customer.id());
+
+        assertDoesNotThrow(() -> {
+            CustomerRefreshToken customerRefreshToken = customerRefreshTokenRepository
+                    .findByCustomerId(customer.id())
+                    .orElseThrow(RuntimeException::new);
+
+            assertThat(customerRefreshToken.requestedAt()).isEqualTo(NOW.minusMinutes(15));
+        });
+    }
+}


### PR DESCRIPTION
## 💻 작업 내역

- 인증에 필요한 액세스 토큰, 리프레시 토큰을 발급하기 위한 로그인 API 구현.

### 아이디어

#### 고민

- 이전에는 리프레시 토큰을 (이하 RT) [여러 클라이언트가 하나의 RT를 공유하는 방식으로 관리]하였으나, 다음과 같은 문제점들이 존재하는 것을 확인.
  1. RT가 만료되었을 때, 모든 클라이언트가 최초 로그인 시점에 관계없이 한 번에 로그아웃됨. 각 클라이언트가 서로 독립적인 세션 환경을 가질 필요성이 있음.
  2. 무한히 중복 로그인이 가능. 로그인이 가능한 클라이언트의 수를 제한할 필요가 있음.

[여러 클라이언트가 하나의 RT를 공유하는 방식으로 관리]: https://github.com/wanted-pre-onboarding-backend-team-s/bab-doduk/pull/14

#### 개선안

- IP 주소를 이용하여 동일 RT를 사용하는 클라이언트 수 제한?
  - IP 주소 정보를 수집하는 것에 대한 개인정보 관련 이슈는 존재하지 않는 것으로 확인.
  - 단, 동일 클라이언트라도 접속한 네트워크에 따라 IP주소는 달라질 수 있기 때문에 비효율적이고, 결정적으로 여전히 동일한 RT를 사용한다는 문제점이 있어 반려.
  - 특정 IP 주소를 제한하는 방식으로는 추후 고려할 수 있을 것 같음.
- **각 클라이언트 별로 RT 발급?**
  - 각 클라이언트마다 독립적인 세션을 보장할 수 있음.
  - 서버가 보유하고 있을 RT 개수에 제한을 두어 동일 계정의 중복 로그인 허용 수를 조정할 수 있음.
  - 현재 비즈니스 로직에 빠르게 적용할 수 있을 것 같아 채택.

[이전 프로젝트에서 적용한 방식]: https://github.com/wanted-pre-onboarding-backend-team-s/bab-doduk/pull/14

### 비즈니스 로직

- 다음의 경우 예외처리
  - 계정명 불일치
  - 비밀번호 불일치
- 액세스 토큰, 리프레시 토큰 발행 후 반환.
- 리프레시 토큰은 중복 로그인 허용 수를 초과할 경우 가장 오래 전에 요청을 송신한 리프레시 토큰을 파기

## 🔎 PR 특이 사항

### 이슈

#### 중복 로그인 허용 RT 수를 초과하는 로그인 요청이 들어오는 경우

- 로그인을 막음?
  - 사용자 경험에 좋지 않은 영향을 끼칠 수 있음. 예를 들어, 특정 클라이언트가 로그아웃을 명시적으로 진행하지 않고 종료. 이렇게 될 경우 해당 클라이언트에 발급된 RT가 만료되기 전까지 로그인을 진행할 수 없으며, 서버에서 RT를 확인해 만료된 RT를 파기하는 로직이 추가되어야 함.
- **로그인을 허용하고, 기존 RT 중 요청 시간이 가장 오래 지난 RT를 파기.**
  - 앞서 살펴본 로그아웃을 하지 않아 발생하는 문제를 해결할 수 있으므로 채택.

#### 토큰 탈취

- 리프레시 토큰이 탈취당하지 않는 것을 전제했으므로, 요청/응답을 주고받는 프로토콜을 암호화하거나 (SSL) 추가적인 탈취 대응 로직을 추가할 필요성이 있음.

### TODO

- 리프레시 토큰 파기 동작을 이벤트 발행 방식의 비동기 동작으로 개선
- 액세스 토큰 재발행 시 리프레시 토큰의 requestedAt 업데이트 로직 추가
- 로그아웃 API 구현