### PR TITLE
✨ Feature: 인증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,8 @@ dependencies {
     // ULID Generator
     implementation 'de.huxhorn.sulky:de.huxhorn.sulky.ulid:8.3.0'
 
-    // Spring Security Web
-    implementation 'org.springframework.security:spring-security-web'
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     // Bouncy Castle Provider
     implementation 'org.bouncycastle:bcprov-jdk18on:1.76'

--- a/src/main/java/com/wanted/jaringoby/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/wanted/jaringoby/common/config/security/SecurityConfig.java
@@ -2,11 +2,24 @@ package com.wanted.jaringoby.common.config.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 public class SecurityConfig {
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+
+        return (web) -> web.ignoring()
+                .requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.POST,
+                        "/customer/v1.0/customers"))
+                .requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.POST,
+                        "/customer/v1.0/sessions"));
+    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/src/main/java/com/wanted/jaringoby/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/wanted/jaringoby/common/config/security/SecurityConfig.java
@@ -1,19 +1,42 @@
 package com.wanted.jaringoby.common.config.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.jaringoby.common.filters.AuthenticationFilter;
+import com.wanted.jaringoby.common.utils.JwtUtil;
+import jakarta.servlet.Filter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .addFilterBefore(authenticationFilter(), BasicAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    private Filter authenticationFilter() {
+        return new AuthenticationFilter(jwtUtil, objectMapper);
+    }
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
-
         return (web) -> web.ignoring()
                 .requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.POST,
                         "/customer/v1.0/customers"))

--- a/src/main/java/com/wanted/jaringoby/common/exceptions/CustomizedException.java
+++ b/src/main/java/com/wanted/jaringoby/common/exceptions/CustomizedException.java
@@ -13,7 +13,20 @@ public class CustomizedException extends RuntimeException {
         this.statusCode = statusCode;
     }
 
+    public String message() {
+        return getMessage();
+    }
+
+    public HttpStatus statusCode() {
+        return statusCode;
+    }
+
+    public ErrorResponse toErrorResponse() {
+        return new ErrorResponse(message());
+    }
+
+    // TODO: toErrorResponseEntity()로 명칭 변경
     public ResponseEntity<ErrorResponse> toResponseEntity() {
-        return new ResponseEntity<>(ErrorResponse.of(getMessage()), statusCode);
+        return new ResponseEntity<>(ErrorResponse.of(message()), statusCode());
     }
 }

--- a/src/main/java/com/wanted/jaringoby/common/exceptions/http/request/InvalidRequestHeaderAuthorizationBearerException.java
+++ b/src/main/java/com/wanted/jaringoby/common/exceptions/http/request/InvalidRequestHeaderAuthorizationBearerException.java
@@ -1,0 +1,11 @@
+package com.wanted.jaringoby.common.exceptions.http.request;
+
+import com.wanted.jaringoby.common.exceptions.CustomizedException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidRequestHeaderAuthorizationBearerException extends CustomizedException {
+
+    public InvalidRequestHeaderAuthorizationBearerException() {
+        super(HttpStatus.UNAUTHORIZED, "잘못된 액세스 토큰 전달자 형식입니다.");
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/common/exceptions/http/request/MissingRequestHeaderAuthorizationException.java
+++ b/src/main/java/com/wanted/jaringoby/common/exceptions/http/request/MissingRequestHeaderAuthorizationException.java
@@ -1,0 +1,11 @@
+package com.wanted.jaringoby.common.exceptions.http.request;
+
+import com.wanted.jaringoby.common.exceptions.CustomizedException;
+import org.springframework.http.HttpStatus;
+
+public class MissingRequestHeaderAuthorizationException extends CustomizedException {
+
+    public MissingRequestHeaderAuthorizationException() {
+        super(HttpStatus.UNAUTHORIZED, "액세스 토큰이 없습니다.");
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/common/exceptions/jwt/TokenDecodingFailedException.java
+++ b/src/main/java/com/wanted/jaringoby/common/exceptions/jwt/TokenDecodingFailedException.java
@@ -1,0 +1,11 @@
+package com.wanted.jaringoby.common.exceptions.jwt;
+
+import com.wanted.jaringoby.common.exceptions.CustomizedException;
+import org.springframework.http.HttpStatus;
+
+public class TokenDecodingFailedException extends CustomizedException {
+
+    public TokenDecodingFailedException() {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 디코딩에 실패했습니다.");
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/common/exceptions/jwt/TokenExpiredException.java
+++ b/src/main/java/com/wanted/jaringoby/common/exceptions/jwt/TokenExpiredException.java
@@ -1,0 +1,11 @@
+package com.wanted.jaringoby.common.exceptions.jwt;
+
+import com.wanted.jaringoby.common.exceptions.CustomizedException;
+import org.springframework.http.HttpStatus;
+
+public class TokenExpiredException extends CustomizedException {
+
+    public TokenExpiredException() {
+        super(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다.");
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/common/filters/AuthenticationFilter.java
+++ b/src/main/java/com/wanted/jaringoby/common/filters/AuthenticationFilter.java
@@ -1,0 +1,79 @@
+package com.wanted.jaringoby.common.filters;
+
+import static com.wanted.jaringoby.common.utils.JwtUtil.CLAIM_CUSTOMER_ID;
+import static com.wanted.jaringoby.common.utils.JwtUtil.CLAIM_TYPE;
+import static com.wanted.jaringoby.common.utils.JwtUtil.REFRESH_TOKEN;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.jaringoby.common.exceptions.http.request.InvalidRequestHeaderAuthorizationBearerException;
+import com.wanted.jaringoby.common.exceptions.http.request.MissingRequestHeaderAuthorizationException;
+import com.wanted.jaringoby.common.exceptions.jwt.TokenDecodingFailedException;
+import com.wanted.jaringoby.common.exceptions.jwt.TokenExpiredException;
+import com.wanted.jaringoby.common.utils.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.GenericFilterBean;
+
+@RequiredArgsConstructor
+public class AuthenticationFilter extends GenericFilterBean {
+
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER = "Bearer ";
+
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void doFilter(
+            ServletRequest servletRequest,
+            ServletResponse servletResponse,
+            FilterChain chain
+    ) throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        try {
+            String authorization = request.getHeader(AUTHORIZATION);
+
+            if (authorization == null) {
+                throw new MissingRequestHeaderAuthorizationException();
+            }
+
+            if (!authorization.startsWith(BEARER)) {
+                throw new InvalidRequestHeaderAuthorizationBearerException();
+            }
+
+            String token = authorization.substring(BEARER.length());
+
+            Map<String, String> claimAndValues = jwtUtil.decodeToken(token);
+
+            if (claimAndValues.get(CLAIM_TYPE).equals(REFRESH_TOKEN)) {
+                request.setAttribute("refreshToken", token);
+            }
+
+            request.setAttribute("customerId", claimAndValues.get(CLAIM_CUSTOMER_ID));
+
+            chain.doFilter(request, response);
+
+        } catch (
+                MissingRequestHeaderAuthorizationException
+                | InvalidRequestHeaderAuthorizationBearerException
+                | TokenDecodingFailedException
+                | TokenExpiredException exception
+        ) {
+            int status = exception.statusCode().value();
+            String body = objectMapper.writeValueAsString(exception.toErrorResponse());
+
+            response.setContentType("application/json; charset=UTF-8");
+            response.setStatus(status);
+            response.getWriter().write(body);
+        }
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/common/utils/JwtUtil.java
+++ b/src/main/java/com/wanted/jaringoby/common/utils/JwtUtil.java
@@ -1,27 +1,39 @@
 package com.wanted.jaringoby.common.utils;
 
 import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.wanted.jaringoby.common.exceptions.jwt.TokenDecodingFailedException;
 import com.wanted.jaringoby.customer.models.customer.CustomerId;
 import java.util.Date;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class JwtUtil {
 
-    private static final String CLAIM_TYPE = "type";
-    private static final String CLAIM_CUSTOMER_ID = "customerId";
+    public static final String CLAIM_TYPE = "type";
+    public static final String CLAIM_CUSTOMER_ID = "customerId";
+
+    public static final String ACCESS_TOKEN = "accessToken";
+    public static final String REFRESH_TOKEN = "refreshToken";
 
     private final Algorithm algorithm;
-    private final Long validTimeAccessToken;
-    private final Long validTimeRefreshToken;
+    private final Long VALID_TIME_ACCESS_TOKEN;
+    private final Long VALID_TIME_REFRESH_TOKEN;
 
     public String issueAccessToken(CustomerId customerId) {
         Date now = new Date();
-        Date expiresAt = new Date(now.getTime() + validTimeAccessToken);
+        Date expiresAt = new Date(now.getTime() + VALID_TIME_ACCESS_TOKEN);
 
         return JWT.create()
-                .withClaim(CLAIM_TYPE, "accessToken")
+                .withClaim(CLAIM_TYPE, ACCESS_TOKEN)
                 .withClaim(CLAIM_CUSTOMER_ID, customerId.value())
                 .withExpiresAt(expiresAt)
                 .sign(algorithm);
@@ -29,12 +41,41 @@ public class JwtUtil {
 
     public String issueRefreshToken(CustomerId customerId) {
         Date now = new Date();
-        Date expiresAt = new Date(now.getTime() + validTimeRefreshToken);
+        Date expiresAt = new Date(now.getTime() + VALID_TIME_REFRESH_TOKEN);
 
         return JWT.create()
-                .withClaim(CLAIM_TYPE, "refreshToken")
+                .withClaim(CLAIM_TYPE, REFRESH_TOKEN)
                 .withClaim(CLAIM_CUSTOMER_ID, customerId.value())
                 .withExpiresAt(expiresAt)
                 .sign(algorithm);
+    }
+
+    public Map<String, String> decodeToken(String token) {
+        JWTVerifier verifier = JWT.require(algorithm)
+                .build();
+
+        try {
+            DecodedJWT decoded = verifier.verify(token);
+
+            Map<String, Claim> claims = decoded.getClaims();
+
+            return claims.entrySet()
+                    .stream()
+                    .filter(claim -> {
+                        String name = claim.getKey();
+                        return name.equals(CLAIM_TYPE) || name.equals(CLAIM_CUSTOMER_ID);
+                    })
+                    .collect(Collectors.toMap(
+                            Entry::getKey,
+                            claim -> claim.getValue().asString()
+                    ));
+
+        } catch (TokenExpiredException exception) {
+            throw new com.wanted.jaringoby.common.exceptions.jwt
+                    .TokenExpiredException();
+
+        } catch (JWTDecodeException exception) {
+            throw new TokenDecodingFailedException();
+        }
     }
 }

--- a/src/test/java/com/wanted/jaringoby/customer/controllers/CustomerControllerTest.java
+++ b/src/test/java/com/wanted/jaringoby/customer/controllers/CustomerControllerTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.wanted.jaringoby.common.config.jwt.JwtConfig;
+import com.wanted.jaringoby.common.config.security.SecurityConfig;
 import com.wanted.jaringoby.common.config.validation.ValidationConfig;
 import com.wanted.jaringoby.common.validations.BindingResultChecker;
 import com.wanted.jaringoby.customer.applications.CreateCustomerService;
@@ -24,7 +26,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(CustomerController.class)
-@Import(ValidationConfig.class)
+@Import({SecurityConfig.class, JwtConfig.class, ValidationConfig.class})
 class CustomerControllerTest {
 
     @Autowired

--- a/src/test/java/com/wanted/jaringoby/session/controllers/SessionControllerTest.java
+++ b/src/test/java/com/wanted/jaringoby/session/controllers/SessionControllerTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.wanted.jaringoby.common.config.jwt.JwtConfig;
+import com.wanted.jaringoby.common.config.security.SecurityConfig;
 import com.wanted.jaringoby.common.config.validation.ValidationConfig;
 import com.wanted.jaringoby.common.validations.BindingResultChecker;
 import com.wanted.jaringoby.session.applications.LoginService;
@@ -24,7 +26,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(SessionController.class)
-@Import(ValidationConfig.class)
+@Import({SecurityConfig.class, JwtConfig.class, ValidationConfig.class})
 class SessionControllerTest {
 
     @Autowired


### PR DESCRIPTION
## 💻 작업 내역

- 인증이 필요한 요청에 대해 토큰의 유효성을 검증하는 AuthenticationFilter 구현.

### Filter vs Interceptor

- HandlerInterceptor 구현체는 InterceptorRegistry에 추가하는 시점에 [제외할 경로는 추가할 수 있지만, 제외할 메서드는 추가할 수 없음.] 따라서 이전 프로젝트에서는 HTTP 메서드와 경로의 쌍으로 인증을 수행하지 않을 요청을 식별하기 위해 별도의 enum을 정의해야 했음.
- 본 프로젝트에서는 Spring Boot Starter Security를 도입해 해당 문제를 해결.
  - WebSecurityCustomizer에 인증을 수행하지 않을 HTTP 메서드와 경로의 쌍 추가
  - 인증을 Filter 구현체인 AuthenticationFilter에서 수행. AuthenticationFilter는 SecurityFilterChain에 추가.
  - Interceptor의 경우에는 발생하는 예외를 RestControllerAdvice 클래스에서 핸들링할 수 있지만, Filter의 경우 Spring Context에 진입하기 전이기 때문에 직접 형식에 맞게 예외 응답을 지정해서 반환.

[제외할 경로는 추가할 수 있지만, 제외할 메서드는 추가할 수 없음.]: https://github.com/wanted-pre-onboarding-backend-team-s/bab-doduk/blob/master/src/main/java/com/wanted/babdoduk/common/config/mvc/WebMvcConfig.java

### 비즈니스 로직

- WebSecurityCustomizer에서 지정한 인증을 수행하지 않을 요청을 제외한 모든 요청이 AuthenticationFilter에 진입
- 다음의 경우 예외 응답 반환
  - 요청 헤더에 Authorization이 없는 경우
  - 요청 헤더 Authorization이 잘못된 토큰 전달자 양식인 경우
  - 토큰이 잘못된 형식인 경우
  - 토큰이 만료된 경우
- 토큰 디코딩 후 Claim 타입, 값의 쌍을 Map으로 도출
- 다음의 값들을 RequestAttribute로 전달
  - customerId
  - refreshToken (토큰의 Claim type이 refreshToken인 경우에만)

## 🔎 PR 특이 사항

### 브랜치명 오류

- authorization -> authentication

### TODO

- 인증 로직을 별도의 서버에서 수행 (레포지토리 분리)