### PR TITLE
✨ Feature: 액세스 토큰 재발행

### DIFF
--- a/src/main/java/com/wanted/jaringoby/session/applications/LogoutService.java
+++ b/src/main/java/com/wanted/jaringoby/session/applications/LogoutService.java
@@ -1,7 +1,7 @@
 package com.wanted.jaringoby.session.applications;
 
 import com.wanted.jaringoby.customer.models.customer.CustomerId;
-import com.wanted.jaringoby.session.exceptions.CustomerRefreshTokenIsNullException;
+import com.wanted.jaringoby.session.exceptions.CustomerRefreshTokenNullException;
 import com.wanted.jaringoby.session.repositories.CustomerRefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,7 +16,7 @@ public class LogoutService {
     @Transactional
     public void logout(String customerId, String refreshToken) {
         if (refreshToken == null) {
-            throw new CustomerRefreshTokenIsNullException();
+            throw new CustomerRefreshTokenNullException();
         }
 
         customerRefreshTokenRepository

--- a/src/main/java/com/wanted/jaringoby/session/applications/ReissueAccessTokenService.java
+++ b/src/main/java/com/wanted/jaringoby/session/applications/ReissueAccessTokenService.java
@@ -1,17 +1,42 @@
 package com.wanted.jaringoby.session.applications;
 
+import com.wanted.jaringoby.common.utils.JwtUtil;
+import com.wanted.jaringoby.customer.models.customer.CustomerId;
 import com.wanted.jaringoby.session.dtos.ReissueAccessTokenResultDto;
+import com.wanted.jaringoby.session.exceptions.CustomerRefreshTokenNotFoundException;
+import com.wanted.jaringoby.session.exceptions.CustomerRefreshTokenNullException;
+import com.wanted.jaringoby.session.repositories.CustomerRefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class ReissueAccessTokenService {
+
+    private final CustomerRefreshTokenRepository customerRefreshTokenRepository;
+    private final JwtUtil jwtUtil;
 
     @Transactional(readOnly = true)
     public ReissueAccessTokenResultDto reissueAccessToken(
             String customerId,
             String refreshToken
     ) {
-        return null;
+        if (refreshToken == null) {
+            throw new CustomerRefreshTokenNullException();
+        }
+
+        if (!customerRefreshTokenRepository.existsByCustomerIdAndValue(
+                CustomerId.of(customerId), refreshToken)) {
+            throw new CustomerRefreshTokenNotFoundException();
+        }
+
+        return ReissueAccessTokenResultDto.builder()
+                .accessToken(issueAccessToken(customerId))
+                .build();
+    }
+
+    private String issueAccessToken(String customerId) {
+        return jwtUtil.issueAccessToken(CustomerId.of(customerId));
     }
 }

--- a/src/main/java/com/wanted/jaringoby/session/applications/ReissueAccessTokenService.java
+++ b/src/main/java/com/wanted/jaringoby/session/applications/ReissueAccessTokenService.java
@@ -1,0 +1,17 @@
+package com.wanted.jaringoby.session.applications;
+
+import com.wanted.jaringoby.session.dtos.ReissueAccessTokenResultDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ReissueAccessTokenService {
+
+    @Transactional(readOnly = true)
+    public ReissueAccessTokenResultDto reissueAccessToken(
+            String customerId,
+            String refreshToken
+    ) {
+        return null;
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/session/controllers/AccessTokenController.java
+++ b/src/main/java/com/wanted/jaringoby/session/controllers/AccessTokenController.java
@@ -1,0 +1,30 @@
+package com.wanted.jaringoby.session.controllers;
+
+import com.wanted.jaringoby.common.response.Response;
+import com.wanted.jaringoby.session.applications.ReissueAccessTokenService;
+import com.wanted.jaringoby.session.dtos.ReissueAccessTokenResultDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/customer/v1.0/access-tokens")
+@RequiredArgsConstructor
+public class AccessTokenController {
+
+    private final ReissueAccessTokenService reissueAccessTokenService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Response<ReissueAccessTokenResultDto> reissueAccessToken(
+            @RequestAttribute("customerId") String customerId,
+            @RequestAttribute(value = "refreshToken", required = false) String refreshToken
+    ) {
+        return Response.of(reissueAccessTokenService
+                .reissueAccessToken(customerId, refreshToken));
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/session/dtos/ReissueAccessTokenResultDto.java
+++ b/src/main/java/com/wanted/jaringoby/session/dtos/ReissueAccessTokenResultDto.java
@@ -1,0 +1,8 @@
+package com.wanted.jaringoby.session.dtos;
+
+import lombok.Builder;
+
+@Builder
+public record ReissueAccessTokenResultDto(String accessToken) {
+
+}

--- a/src/main/java/com/wanted/jaringoby/session/exceptions/CustomerRefreshTokenNotFoundException.java
+++ b/src/main/java/com/wanted/jaringoby/session/exceptions/CustomerRefreshTokenNotFoundException.java
@@ -1,0 +1,11 @@
+package com.wanted.jaringoby.session.exceptions;
+
+import com.wanted.jaringoby.common.exceptions.CustomizedException;
+import org.springframework.http.HttpStatus;
+
+public class CustomerRefreshTokenNotFoundException extends CustomizedException {
+
+    public CustomerRefreshTokenNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "존재하지 않는 리프레시 토큰입니다.");
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/session/exceptions/CustomerRefreshTokenNullException.java
+++ b/src/main/java/com/wanted/jaringoby/session/exceptions/CustomerRefreshTokenNullException.java
@@ -3,9 +3,9 @@ package com.wanted.jaringoby.session.exceptions;
 import com.wanted.jaringoby.common.exceptions.CustomizedException;
 import org.springframework.http.HttpStatus;
 
-public class CustomerRefreshTokenIsNullException extends CustomizedException {
+public class CustomerRefreshTokenNullException extends CustomizedException {
 
-    public CustomerRefreshTokenIsNullException() {
+    public CustomerRefreshTokenNullException() {
         super(HttpStatus.BAD_REQUEST, "전달된 리프레시 토큰이 없습니다.");
     }
 }

--- a/src/main/java/com/wanted/jaringoby/session/repositories/CustomerRefreshTokenRepository.java
+++ b/src/main/java/com/wanted/jaringoby/session/repositories/CustomerRefreshTokenRepository.java
@@ -15,4 +15,6 @@ public interface CustomerRefreshTokenRepository extends
     Optional<CustomerRefreshToken> findByCustomerId(CustomerId customerId);
 
     void deleteByCustomerIdAndValue(CustomerId customerId, String refreshToken);
+
+    boolean existsByCustomerIdAndValue(CustomerId customerId, String refreshToken);
 }

--- a/src/test/java/com/wanted/jaringoby/session/applications/LogoutServiceTest.java
+++ b/src/test/java/com/wanted/jaringoby/session/applications/LogoutServiceTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.wanted.jaringoby.customer.models.customer.CustomerId;
-import com.wanted.jaringoby.session.exceptions.CustomerRefreshTokenIsNullException;
+import com.wanted.jaringoby.session.exceptions.CustomerRefreshTokenNullException;
 import com.wanted.jaringoby.session.repositories.CustomerRefreshTokenRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -51,7 +51,7 @@ class LogoutServiceTest {
         @DisplayName("리프레시 토큰이 null로 전달된 경우 예외 발생")
         @Test
         void logout() {
-            assertThrows(CustomerRefreshTokenIsNullException.class, () ->
+            assertThrows(CustomerRefreshTokenNullException.class, () ->
                     logoutService.logout(CUSTOMER_ID, null));
 
             verify(customerRefreshTokenRepository, never())

--- a/src/test/java/com/wanted/jaringoby/session/applications/ReissueAccessTokenServiceTest.java
+++ b/src/test/java/com/wanted/jaringoby/session/applications/ReissueAccessTokenServiceTest.java
@@ -1,0 +1,83 @@
+package com.wanted.jaringoby.session.applications;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.wanted.jaringoby.common.utils.JwtUtil;
+import com.wanted.jaringoby.customer.models.customer.CustomerId;
+import com.wanted.jaringoby.session.dtos.ReissueAccessTokenResultDto;
+import com.wanted.jaringoby.session.exceptions.CustomerRefreshTokenNotFoundException;
+import com.wanted.jaringoby.session.exceptions.CustomerRefreshTokenNullException;
+import com.wanted.jaringoby.session.repositories.CustomerRefreshTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ReissueAccessTokenServiceTest {
+
+    private ReissueAccessTokenService reissueAccessTokenService;
+    private CustomerRefreshTokenRepository customerRefreshTokenRepository;
+    private JwtUtil jwtUtil;
+
+    @BeforeEach
+    void setUp() {
+        customerRefreshTokenRepository = mock(CustomerRefreshTokenRepository.class);
+        jwtUtil = mock(JwtUtil.class);
+        reissueAccessTokenService = new ReissueAccessTokenService(
+                customerRefreshTokenRepository,
+                jwtUtil
+        );
+    }
+
+    private static final String CUSTOMER_ID = "CUSTOMER_ID";
+    private static final String REFRESH_TOKEN = "REFRESH_TOKEN";
+
+    @DisplayName("성공")
+    @Nested
+    class Success {
+
+        private static final String ACCESS_TOKEN = "ACCESS_TOKEN";
+
+        @DisplayName("리프레시 토큰이 존재하는 경우, 액세스 토큰을 재발행해 반환")
+        @Test
+        void reissueAccessToken() {
+            given(customerRefreshTokenRepository
+                    .existsByCustomerIdAndValue(CustomerId.of(CUSTOMER_ID), REFRESH_TOKEN))
+                    .willReturn(true);
+
+            given(jwtUtil.issueAccessToken(CustomerId.of(CUSTOMER_ID)))
+                    .willReturn(ACCESS_TOKEN);
+
+            ReissueAccessTokenResultDto reissueAccessTokenResultDto
+                    = reissueAccessTokenService.reissueAccessToken(CUSTOMER_ID, REFRESH_TOKEN);
+
+            assertThat(reissueAccessTokenResultDto).isNotNull();
+        }
+    }
+
+    @DisplayName("실패")
+    @Nested
+    class Failure {
+
+        @DisplayName("리프레시 토큰이 전달되지 않은 경우 예외처리")
+        @Test
+        void customerRefreshTokenNull() {
+            assertThrows(CustomerRefreshTokenNullException.class, () ->
+                    reissueAccessTokenService.reissueAccessToken(CUSTOMER_ID, null));
+        }
+
+        @DisplayName("리프레시 토큰이 존재하지 않는 경우 예외처리")
+        @Test
+        void customerRefreshTokenNotFound() {
+            given(customerRefreshTokenRepository
+                    .existsByCustomerIdAndValue(CustomerId.of(CUSTOMER_ID), REFRESH_TOKEN))
+                    .willReturn(false);
+
+            assertThrows(CustomerRefreshTokenNotFoundException.class, () ->
+                    reissueAccessTokenService.reissueAccessToken(CUSTOMER_ID, REFRESH_TOKEN));
+        }
+    }
+}

--- a/src/test/java/com/wanted/jaringoby/session/controllers/AccessTokenControllerTest.java
+++ b/src/test/java/com/wanted/jaringoby/session/controllers/AccessTokenControllerTest.java
@@ -1,0 +1,98 @@
+package com.wanted.jaringoby.session.controllers;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.wanted.jaringoby.common.config.jwt.JwtConfig;
+import com.wanted.jaringoby.common.config.security.SecurityConfig;
+import com.wanted.jaringoby.common.utils.JwtUtil;
+import com.wanted.jaringoby.customer.models.customer.CustomerId;
+import com.wanted.jaringoby.customer.repositories.CustomerRepository;
+import com.wanted.jaringoby.session.applications.ReissueAccessTokenService;
+import com.wanted.jaringoby.session.dtos.ReissueAccessTokenResultDto;
+import com.wanted.jaringoby.session.exceptions.CustomerRefreshTokenIsNullException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AccessTokenController.class)
+@Import({SecurityConfig.class, JwtConfig.class})
+class AccessTokenControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ReissueAccessTokenService reissueAccessTokenService;
+
+    @MockBean
+    private CustomerRepository customerRepository;
+
+    @SpyBean
+    private JwtUtil jwtUtil;
+
+    @DisplayName("POST /customer/v1.0/access-tokens")
+    @Nested
+    class PostAccessTokens {
+
+        private static final String CUSTOMER_ID = "CUSTOMER_ID";
+        private static final String ACCESS_TOKEN = "ACCESS_TOKEN";
+
+        @BeforeEach
+        void setUp() {
+            given(customerRepository.existsById(CustomerId.of(CUSTOMER_ID)))
+                    .willReturn(true);
+        }
+
+        @DisplayName("성공")
+        @Nested
+        class Success {
+
+            @DisplayName("리프레시 토큰을 전달하는 경우, 반환된 액세스 토큰을 응답으로 전달")
+            @Test
+            void reissueAccessToken() throws Exception {
+                String refreshToken = jwtUtil.issueRefreshToken(CustomerId.of(CUSTOMER_ID));
+
+                ReissueAccessTokenResultDto reissueAccessTokenResultDto
+                        = ReissueAccessTokenResultDto.builder()
+                        .accessToken(ACCESS_TOKEN)
+                        .build();
+
+                given(reissueAccessTokenService
+                        .reissueAccessToken(CUSTOMER_ID, refreshToken))
+                        .willReturn(reissueAccessTokenResultDto);
+
+                mockMvc.perform(post("/customer/v1.0/access-tokens")
+                                .header("Authorization", "Bearer " + refreshToken))
+                        .andExpect(status().isCreated());
+            }
+        }
+
+        @DisplayName("실패")
+        @Nested
+        class Failure {
+            @DisplayName("리프레시 토큰이 아닌 토큰을 전달하는 경우, null refreshToken 전달하고 "
+                    + "리프레시 토큰 미존재 예외 반환")
+            @Test
+            void customerRefreshTokenIsNull() throws Exception {
+                String token = jwtUtil.issueAccessToken(CustomerId.of(CUSTOMER_ID));
+
+                given(reissueAccessTokenService
+                        .reissueAccessToken(CUSTOMER_ID, null))
+                        .willThrow(new CustomerRefreshTokenIsNullException());
+
+                mockMvc.perform(post("/customer/v1.0/access-tokens")
+                                .header("Authorization", "Bearer " + token))
+                        .andExpect(status().isBadRequest());
+            }
+        }
+    }
+}

--- a/src/test/java/com/wanted/jaringoby/session/controllers/AccessTokenControllerTest.java
+++ b/src/test/java/com/wanted/jaringoby/session/controllers/AccessTokenControllerTest.java
@@ -11,7 +11,7 @@ import com.wanted.jaringoby.customer.models.customer.CustomerId;
 import com.wanted.jaringoby.customer.repositories.CustomerRepository;
 import com.wanted.jaringoby.session.applications.ReissueAccessTokenService;
 import com.wanted.jaringoby.session.dtos.ReissueAccessTokenResultDto;
-import com.wanted.jaringoby.session.exceptions.CustomerRefreshTokenIsNullException;
+import com.wanted.jaringoby.session.exceptions.CustomerRefreshTokenNullException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -82,12 +82,12 @@ class AccessTokenControllerTest {
             @DisplayName("리프레시 토큰이 아닌 토큰을 전달하는 경우, null refreshToken 전달하고 "
                     + "리프레시 토큰 미존재 예외 반환")
             @Test
-            void customerRefreshTokenIsNull() throws Exception {
+            void customerRefreshTokenNull() throws Exception {
                 String token = jwtUtil.issueAccessToken(CustomerId.of(CUSTOMER_ID));
 
                 given(reissueAccessTokenService
                         .reissueAccessToken(CUSTOMER_ID, null))
-                        .willThrow(new CustomerRefreshTokenIsNullException());
+                        .willThrow(new CustomerRefreshTokenNullException());
 
                 mockMvc.perform(post("/customer/v1.0/access-tokens")
                                 .header("Authorization", "Bearer " + token))

--- a/src/test/java/com/wanted/jaringoby/session/controllers/SessionControllerTest.java
+++ b/src/test/java/com/wanted/jaringoby/session/controllers/SessionControllerTest.java
@@ -20,7 +20,7 @@ import com.wanted.jaringoby.session.applications.LoginService;
 import com.wanted.jaringoby.session.applications.LogoutService;
 import com.wanted.jaringoby.session.dtos.LoginRequestDto;
 import com.wanted.jaringoby.session.dtos.LoginResponseDto;
-import com.wanted.jaringoby.session.exceptions.CustomerRefreshTokenIsNullException;
+import com.wanted.jaringoby.session.exceptions.CustomerRefreshTokenNullException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -164,13 +164,13 @@ class SessionControllerTest {
             @DisplayName("리프레시 토큰이 아닌 토큰을 전달하는 경우, null refreshToken 전달하고 "
                     + "리프레시 토큰 미존재 예외 반환")
             @Test
-            void customerRefreshTokenIsNull() throws Exception {
+            void customerRefreshTokenNull() throws Exception {
                 token = jwtUtil.issueAccessToken(CustomerId.of(CUSTOMER_ID));
 
                 given(customerRepository.existsById(CustomerId.of(CUSTOMER_ID)))
                         .willReturn(true);
 
-                doThrow(new CustomerRefreshTokenIsNullException())
+                doThrow(new CustomerRefreshTokenNullException())
                         .when(logoutService)
                         .logout(CUSTOMER_ID, null);
 

--- a/src/test/java/com/wanted/jaringoby/session/controllers/SessionControllerTest.java
+++ b/src/test/java/com/wanted/jaringoby/session/controllers/SessionControllerTest.java
@@ -164,7 +164,7 @@ class SessionControllerTest {
             @DisplayName("리프레시 토큰이 아닌 토큰을 전달하는 경우, null refreshToken 전달하고 "
                     + "리프레시 토큰 미존재 예외 반환")
             @Test
-            void logout() throws Exception {
+            void customerRefreshTokenIsNull() throws Exception {
                 token = jwtUtil.issueAccessToken(CustomerId.of(CUSTOMER_ID));
 
                 given(customerRepository.existsById(CustomerId.of(CUSTOMER_ID)))


### PR DESCRIPTION
## 💻 작업 내역

- 유효한 리프레시 토큰을 이용해 액세스 토큰을 재발행하는 API 구현.

### 비즈니스 로직

- 다음의 경우 예외처리
  - 전달된 리프레시 토큰이 없는 경우
  - 리프레시 토큰이 존재하지 않는 경우
- 예외처리되지 않았을 시, 액세스 토큰을 재발행해 반환

## 🔎 PR 특이 사항

없음.