### PR TITLE
✏️ Style: API 요청 경로 양식 수정

### DIFF
--- a/src/main/java/com/wanted/jaringoby/category/controllers/CategoryController.java
+++ b/src/main/java/com/wanted/jaringoby/category/controllers/CategoryController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/customer/v1.0/categories")
+@RequestMapping("/v1.0/customer/categories")
 @RequiredArgsConstructor
 public class CategoryController {
 

--- a/src/main/java/com/wanted/jaringoby/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/wanted/jaringoby/common/config/security/SecurityConfig.java
@@ -58,9 +58,9 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring()
                 .requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.POST,
-                        "/customer/v1.0/customers"))
+                        "/v1.0/customer/customers"))
                 .requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.POST,
-                        "/customer/v1.0/sessions"));
+                        "/v1.0/customer/sessions"));
     }
 
     @Bean

--- a/src/main/java/com/wanted/jaringoby/common/filters/AuthenticationFilter.java
+++ b/src/main/java/com/wanted/jaringoby/common/filters/AuthenticationFilter.java
@@ -19,8 +19,8 @@ public abstract class AuthenticationFilter extends CustomFilter {
 
     private final List<AntPathRequestMatcher> requestMatchersForRefreshTokenBasedAuthentication
             = List.of(
-            AntPathRequestMatcher.antMatcher(HttpMethod.DELETE, "/customer/v1.0/sessions"),
-            AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/customer/v1.0/access-tokens")
+            AntPathRequestMatcher.antMatcher(HttpMethod.DELETE, "/v1.0/customer/sessions"),
+            AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/v1.0/customer/access-tokens")
     );
 
     public abstract void doFilter(

--- a/src/main/java/com/wanted/jaringoby/customer/controllers/CustomerController.java
+++ b/src/main/java/com/wanted/jaringoby/customer/controllers/CustomerController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/customer/v1.0/customers")
+@RequestMapping("/v1.0/customer/customers")
 @RequiredArgsConstructor
 public class CustomerController {
 

--- a/src/main/java/com/wanted/jaringoby/ledger/controllers/LedgerController.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/controllers/LedgerController.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/customer/v1.0/ledgers")
+@RequestMapping("/v1.0/customer/ledgers")
 @RequiredArgsConstructor
 public class LedgerController {
 

--- a/src/main/java/com/wanted/jaringoby/session/controllers/AccessTokenController.java
+++ b/src/main/java/com/wanted/jaringoby/session/controllers/AccessTokenController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/customer/v1.0/access-tokens")
+@RequestMapping("/v1.0/customer/access-tokens")
 @RequiredArgsConstructor
 public class AccessTokenController {
 

--- a/src/main/java/com/wanted/jaringoby/session/controllers/SessionController.java
+++ b/src/main/java/com/wanted/jaringoby/session/controllers/SessionController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/customer/v1.0/sessions")
+@RequestMapping("/v1.0/customer/sessions")
 @RequiredArgsConstructor
 public class SessionController {
 

--- a/src/test/java/com/wanted/jaringoby/category/controllers/CategoryControllerTest.java
+++ b/src/test/java/com/wanted/jaringoby/category/controllers/CategoryControllerTest.java
@@ -41,7 +41,7 @@ class CategoryControllerTest {
     @SpyBean
     private JwtUtil jwtUtil;
 
-    @DisplayName("GET /customer/v1.0/categories")
+    @DisplayName("GET /v1.0/customer/categories")
     @Nested
     class GetCategories {
 
@@ -72,7 +72,7 @@ class CategoryControllerTest {
 
             given(getCategoryListService.getCategories()).willReturn(getCategoryListResponseDto);
 
-            mockMvc.perform(get("/customer/v1.0/categories")
+            mockMvc.perform(get("/v1.0/customer/categories")
                             .header("Authorization", "Bearer " + accessToken))
                     .andExpect(status().isOk())
                     .andExpect(content().string(containsString("""

--- a/src/test/java/com/wanted/jaringoby/customer/controllers/CustomerControllerTest.java
+++ b/src/test/java/com/wanted/jaringoby/customer/controllers/CustomerControllerTest.java
@@ -40,7 +40,7 @@ class CustomerControllerTest {
     @SpyBean
     private BindingResultChecker bindingResultChecker;
 
-    @DisplayName("POST /customer/v1.0/customers")
+    @DisplayName("POST /v1.0/customer/customers")
     @Nested
     class PostCustomers {
 
@@ -61,7 +61,7 @@ class CustomerControllerTest {
                 given(createCustomerService.createCustomer(any(CreateCustomerRequestDto.class)))
                         .willReturn(createCustomerResponseDto);
 
-                mockMvc.perform(post("/customer/v1.0/customers")
+                mockMvc.perform(post("/v1.0/customer/customers")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)
                                 .content("""
@@ -79,8 +79,8 @@ class CustomerControllerTest {
         @Nested
         class Failure {
 
-            private void performAndExpectIsBadRequest(String content) throws Exception {
-                mockMvc.perform(post("/customer/v1.0/customers")
+            private void performAndExpectBadRequest(String content) throws Exception {
+                mockMvc.perform(post("/v1.0/customer/customers")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)
                                 .content(
@@ -95,7 +95,7 @@ class CustomerControllerTest {
             @DisplayName("username 미입력된 경우 예외처리")
             @Test
             void blankUsername() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "password": "Password!1",
                             "reconfirmPassword": "Password!1"
@@ -106,7 +106,7 @@ class CustomerControllerTest {
             @DisplayName("password 미입력된 경우 예외처리")
             @Test
             void blankPassword() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "username": "hsjkdss228",
                             "password": null,
@@ -118,7 +118,7 @@ class CustomerControllerTest {
             @DisplayName("reconfirmPassword 미입력된 경우 예외처리")
             @Test
             void blankReconfirmPassword() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "username": "hsjkdss228",
                             "password": "Password!1",
@@ -130,7 +130,7 @@ class CustomerControllerTest {
             @DisplayName("username 입력 조건에 부합하지 않을 경우 예외처리 (4자 미만)")
             @Test
             void invalidUsernameUnder4() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "username": "ua7",
                             "password": "Password!1",
@@ -142,7 +142,7 @@ class CustomerControllerTest {
             @DisplayName("username 입력 조건에 부합하지 않을 경우 예외처리 (16자 초과)")
             @Test
             void invalidUsernameOver16() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "username": "username12username12",
                             "password": "Password!1",
@@ -154,7 +154,7 @@ class CustomerControllerTest {
             @DisplayName("username 입력 조건에 부합하지 않을 경우 예외처리 (영어 소문자 미포함)")
             @Test
             void invalidUsernameWithoutLowercase() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "username": "11223344",
                             "password": "Password!1",
@@ -166,7 +166,7 @@ class CustomerControllerTest {
             @DisplayName("username 입력 조건에 부합하지 않을 경우 예외처리 (영어 소문자, 숫자 이외 문자 포함)")
             @Test
             void invalidUsernameWithDisallowedCharacters() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "username": "hsjkdss228%",
                             "password": "Password!1",
@@ -178,7 +178,7 @@ class CustomerControllerTest {
             @DisplayName("password 입력 조건에 부합하지 않을 경우 예외처리 (영어 대문자 미포함)")
             @Test
             void invalidPasswordWithoutUppercase() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "username": "hsjkdss228",
                             "password": "assword!1",
@@ -190,7 +190,7 @@ class CustomerControllerTest {
             @DisplayName("password 입력 조건에 부합하지 않을 경우 예외처리 (영어 소문자 미포함)")
             @Test
             void invalidPasswordWithoutLowercase() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "username": "hsjkdss228",
                             "password": "PASSWORD!1",
@@ -202,7 +202,7 @@ class CustomerControllerTest {
             @DisplayName("password 입력 조건에 부합하지 않을 경우 예외처리 (영어 숫자 미포함)")
             @Test
             void invalidPasswordWithoutDigit() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "username": "hsjkdss228",
                             "password": "Password!",
@@ -214,7 +214,7 @@ class CustomerControllerTest {
             @DisplayName("password 입력 조건에 부합하지 않을 경우 예외처리 (키보드 입력 가능한 특수문자 미포함)")
             @Test
             void invalidPasswordWithoutSpecialCharacters() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "username": "hsjkdss228",
                             "password": "Password1",
@@ -227,7 +227,7 @@ class CustomerControllerTest {
                     + "(영어 대문자, 소문자, 숫자, 키보드 입력 가능한 특수문자 이외 문자 포함)")
             @Test
             void invalidPasswordWithDisallowedCharacters() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "username": "hsjkdss228",
                             "password": "Password!1※",
@@ -239,7 +239,7 @@ class CustomerControllerTest {
             @DisplayName("password 입력 조건에 부합하지 않을 경우 예외처리 (5자 미만)")
             @Test
             void invalidPasswordUnder5() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "username": "hsjkdss228",
                             "password": "Pa!1",

--- a/src/test/java/com/wanted/jaringoby/ledger/controllers/LedgerControllerTest.java
+++ b/src/test/java/com/wanted/jaringoby/ledger/controllers/LedgerControllerTest.java
@@ -54,17 +54,6 @@ class LedgerControllerTest {
     @SpyBean
     private BindingResultChecker bindingResultChecker;
 
-    private void performAndExpectIsBadRequest(String content) throws Exception {
-        mockMvc.perform(post("/customer/v1.0/ledgers")
-                        .header("Authorization", "Bearer " + accessToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .content(
-                                content
-                        ))
-                .andExpect(status().isBadRequest());
-    }
-
     private String accessToken;
 
     private static final String CUSTOMER_ID = "CUSTOMER_ID";
@@ -80,7 +69,7 @@ class LedgerControllerTest {
     @MockBean
     private GetOngoingLedgerService getOngoingLedgerService;
 
-    @DisplayName("GET /customer/v1.0/ledgers/now")
+    @DisplayName("GET /v1.0/customer/ledgers/now")
     @Nested
     class GetLedgersNow {
 
@@ -115,7 +104,7 @@ class LedgerControllerTest {
             given(getOngoingLedgerService.getOngoingLedger(CUSTOMER_ID))
                     .willReturn(getLedgerDetailResponseDto);
 
-            mockMvc.perform(get("/customer/v1.0/ledgers/now")
+            mockMvc.perform(get("/v1.0/customer/ledgers/now")
                             .header("Authorization", "Bearer " + accessToken))
                     .andExpect(status().isOk());
         }
@@ -124,11 +113,22 @@ class LedgerControllerTest {
     @MockBean
     private CreateLedgerService createLedgerService;
 
-    @DisplayName("POST /customer/v1.0/ledgers")
+    @DisplayName("POST /v1.0/customer/ledgers")
     @Nested
     class PostLedgers {
 
         private static final String LEDGER_ID = "LEDGER_ID";
+
+        private void performAndExpectBadRequest(String content) throws Exception {
+            mockMvc.perform(post("/v1.0/customer/ledgers")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(
+                                    content
+                            ))
+                    .andExpect(status().isBadRequest());
+        }
 
         @DisplayName("성공")
         @Nested
@@ -146,7 +146,7 @@ class LedgerControllerTest {
                         .createLedger(eq(CUSTOMER_ID), any(CreateLedgerRequestDto.class)))
                         .willReturn(createLedgerResponseDto);
 
-                mockMvc.perform(post("/customer/v1.0/ledgers")
+                mockMvc.perform(post("/v1.0/customer/ledgers")
                                 .header("Authorization", "Bearer " + accessToken)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)
@@ -177,7 +177,7 @@ class LedgerControllerTest {
             @DisplayName("시작일 입력되지 않은 경우 예외처리")
             @Test
             void nullStartDate() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                              "endDate": "2023-12-24",
                              "budgets": [
@@ -197,7 +197,7 @@ class LedgerControllerTest {
             @DisplayName("종료일 입력되지 않은 경우 예외처리")
             @Test
             void nullEndDate() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                              "startDate": "2023-11-24",
                              "endDate": null,
@@ -218,7 +218,7 @@ class LedgerControllerTest {
             @DisplayName("예산이 하나 이상 입력되지 않은 경우 예외처리")
             @Test
             void emptyBudgets() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                              "startDate": "2023-11-24",
                              "endDate": "2023-12-23",
@@ -230,7 +230,7 @@ class LedgerControllerTest {
             @DisplayName("카테고리가 입력되지 않은 예산이 존재하는 경우 예외처리")
             @Test
             void blankCategory() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                              "startDate": "2023-11-24",
                              "endDate": "2023-12-23",
@@ -251,7 +251,7 @@ class LedgerControllerTest {
             @DisplayName("금액이 입력되지 않은 예산이 존재하는 경우 예외처리")
             @Test
             void nullAmount() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                              "startDate": "2023-11-24",
                              "endDate": "2023-12-23",
@@ -271,7 +271,7 @@ class LedgerControllerTest {
             @DisplayName("입력된 예산의 금액 중 1원 이하가 존재하는 경우 예외처리")
             @Test
             void amountLessThan1() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                              "startDate": "2023-11-24",
                              "endDate": "2023-12-23",
@@ -294,11 +294,22 @@ class LedgerControllerTest {
     @MockBean
     private ModifyLedgerPeriodService modifyLedgerPeriodService;
 
-    @DisplayName("PATCH /customer/v1.0/ledgers/{ledger-id}/period")
+    @DisplayName("PATCH /v1.0/customer/ledgers/{ledger-id}/period")
     @Nested
     class PatchLedgersPeriod {
 
         private static final String LEDGER_ID = "LEDGER_ID";
+
+        private void performAndExpectBadRequest(String content) throws Exception {
+            mockMvc.perform(patch("/v1.0/customer/ledgers/" + LEDGER_ID + "/period")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(
+                                    content
+                            ))
+                    .andExpect(status().isBadRequest());
+        }
 
         @DisplayName("성공")
         @Nested
@@ -307,7 +318,7 @@ class LedgerControllerTest {
             @DisplayName("전달된 Ledger 식별자에 대해 시작일, 종료일 변경 수행 메서드 호출")
             @Test
             void modifyPeriod() throws Exception {
-                mockMvc.perform(patch("/customer/v1.0/ledgers/" + LEDGER_ID + "/period")
+                mockMvc.perform(patch("/v1.0/customer/ledgers/" + LEDGER_ID + "/period")
                                 .header("Authorization", "Bearer " + accessToken)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)
@@ -334,7 +345,7 @@ class LedgerControllerTest {
             @DisplayName("시작일 입력되지 않은 경우 예외처리")
             @Test
             void nullStartDate() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "endDate": "2023-12-15"
                         }
@@ -344,7 +355,7 @@ class LedgerControllerTest {
             @DisplayName("종료일 입력되지 않은 경우 예외처리")
             @Test
             void nullEndDate() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "startDate": "2023-12-15",
                             "endDate": null

--- a/src/test/java/com/wanted/jaringoby/session/controllers/AccessTokenControllerTest.java
+++ b/src/test/java/com/wanted/jaringoby/session/controllers/AccessTokenControllerTest.java
@@ -41,7 +41,7 @@ class AccessTokenControllerTest {
     @SpyBean
     private JwtUtil jwtUtil;
 
-    @DisplayName("POST /customer/v1.0/access-tokens")
+    @DisplayName("POST /v1.0/customer/access-tokens")
     @Nested
     class PostAccessTokens {
 
@@ -72,7 +72,7 @@ class AccessTokenControllerTest {
                         .reissueAccessToken(CUSTOMER_ID, refreshToken))
                         .willReturn(reissueAccessTokenResponseDto);
 
-                mockMvc.perform(post("/customer/v1.0/access-tokens")
+                mockMvc.perform(post("/v1.0/customer/access-tokens")
                                 .header("Authorization", "Bearer " + refreshToken))
                         .andExpect(status().isCreated());
             }
@@ -87,7 +87,7 @@ class AccessTokenControllerTest {
             void customerRefreshTokenNull() throws Exception {
                 String token = jwtUtil.issueAccessToken(CustomerId.of(CUSTOMER_ID));
 
-                mockMvc.perform(post("/customer/v1.0/access-tokens")
+                mockMvc.perform(post("/v1.0/customer/access-tokens")
                                 .header("Authorization", "Bearer " + token))
                         .andExpect(status().isUnauthorized());
 

--- a/src/test/java/com/wanted/jaringoby/session/controllers/SessionControllerTest.java
+++ b/src/test/java/com/wanted/jaringoby/session/controllers/SessionControllerTest.java
@@ -43,7 +43,7 @@ class SessionControllerTest {
     @SpyBean
     private BindingResultChecker bindingResultChecker;
 
-    @DisplayName("POST /customer/v1.0/sessions")
+    @DisplayName("POST /v1.0/customer/sessions")
     @Nested
     class PostSessions {
 
@@ -65,7 +65,7 @@ class SessionControllerTest {
                 given(loginService.login(any(LoginRequestDto.class)))
                         .willReturn(loginResponseDto);
 
-                mockMvc.perform(post("/customer/v1.0/sessions")
+                mockMvc.perform(post("/v1.0/customer/sessions")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)
                                 .content("""
@@ -82,8 +82,8 @@ class SessionControllerTest {
         @Nested
         class Failure {
 
-            private void performAndExpectIsBadRequest(String content) throws Exception {
-                mockMvc.perform(post("/customer/v1.0/sessions")
+            private void performAndExpectBadRequest(String content) throws Exception {
+                mockMvc.perform(post("/v1.0/customer/sessions")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)
                                 .content(
@@ -98,7 +98,7 @@ class SessionControllerTest {
             @DisplayName("username 미입력된 경우 예외처리")
             @Test
             void blankUsername() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "username": "  ",
                             "password": "Password!1"
@@ -109,7 +109,7 @@ class SessionControllerTest {
             @DisplayName("password 미입력된 경우 예외처리")
             @Test
             void blankPassword() throws Exception {
-                performAndExpectIsBadRequest("""
+                performAndExpectBadRequest("""
                         {
                             "username": "hsjkdss228"
                         }
@@ -129,7 +129,7 @@ class SessionControllerTest {
 
     private static final String CUSTOMER_ID = "CUSTOMER_ID";
 
-    @DisplayName("DELETE /customer/v1.0/sessions")
+    @DisplayName("DELETE /v1.0/customer/sessions")
     @Nested
     class DeleteSessions {
 
@@ -147,7 +147,7 @@ class SessionControllerTest {
                 given(customerRepository.existsById(CustomerId.of(CUSTOMER_ID)))
                         .willReturn(true);
 
-                mockMvc.perform(delete("/customer/v1.0/sessions")
+                mockMvc.perform(delete("/v1.0/customer/sessions")
                                 .header("Authorization", "Bearer " + token))
                         .andExpect(status().isNoContent());
 
@@ -167,7 +167,7 @@ class SessionControllerTest {
                 given(customerRepository.existsById(CustomerId.of(CUSTOMER_ID)))
                         .willReturn(true);
 
-                mockMvc.perform(delete("/customer/v1.0/sessions")
+                mockMvc.perform(delete("/v1.0/customer/sessions")
                                 .header("Authorization", "Bearer " + token))
                         .andExpect(status().isUnauthorized());
 


### PR DESCRIPTION
## 💻 작업 내역

- 클라이언트가 요청해야 할 API 양식을 수정하는 작업 수행.

### 변경 이전 양식

- `/요청 클라이언트 도메인/버전/경로명`
  - ex) `/customer/v1.0/ledgers`

### 변경 이후 양식

- `/버전/요청 클라이언트 도메인/경로명`
  - ex) `/v1.0/customer/ledgers`

### 변경 대상

- 각 API 요청 매핑 Controller
- SecurityConfig
  - 인증/인가 미수행 API 식별 정의부
- AuthenticationFilter
  - 리프레시 토큰 기반 인증 수행 API 식별 정의부