### PR TITLE
✨ Feature: 특정 예산 관리 내 예산 변경

### DIFF
--- a/src/main/java/com/wanted/jaringoby/ledger/applications/CreateLedgerService.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/applications/CreateLedgerService.java
@@ -5,6 +5,7 @@ import static com.wanted.jaringoby.common.constants.Date.TODAY;
 import com.wanted.jaringoby.category.exceptions.CategoryDuplicatedException;
 import com.wanted.jaringoby.category.exceptions.CategoryNotFoundException;
 import com.wanted.jaringoby.category.models.Category;
+import com.wanted.jaringoby.common.models.Money;
 import com.wanted.jaringoby.common.utils.UlidGenerator;
 import com.wanted.jaringoby.customer.models.customer.CustomerId;
 import com.wanted.jaringoby.ledger.dtos.BudgetRequestDto;
@@ -59,8 +60,8 @@ public class CreateLedgerService {
                 .map(budgetRequestDto -> Budget.builder()
                         .id(ulidGenerator.createRandomBudgetULID())
                         .ledgerId(ledger.id())
-                        .category(budgetRequestDto.getCategory())
-                        .amount(budgetRequestDto.getAmount())
+                        .category(Category.of(budgetRequestDto.getCategory()))
+                        .amount(Money.of(budgetRequestDto.getAmount()))
                         .build())
                 .toList();
 

--- a/src/main/java/com/wanted/jaringoby/ledger/applications/CreateLedgerService.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/applications/CreateLedgerService.java
@@ -7,7 +7,7 @@ import com.wanted.jaringoby.category.exceptions.CategoryNotFoundException;
 import com.wanted.jaringoby.category.models.Category;
 import com.wanted.jaringoby.common.utils.UlidGenerator;
 import com.wanted.jaringoby.customer.models.customer.CustomerId;
-import com.wanted.jaringoby.ledger.dtos.CreateBudgetRequestDto;
+import com.wanted.jaringoby.ledger.dtos.BudgetRequestDto;
 import com.wanted.jaringoby.ledger.dtos.CreateLedgerRequestDto;
 import com.wanted.jaringoby.ledger.dtos.CreateLedgerResponseDto;
 import com.wanted.jaringoby.ledger.exceptions.LedgerPeriodInvalidException;
@@ -39,12 +39,12 @@ public class CreateLedgerService {
     ) {
         LocalDate startDate = createLedgerRequestDto.getStartDate();
         LocalDate endDate = createLedgerRequestDto.getEndDate();
-        List<CreateBudgetRequestDto> createBudgetRequestDtos = createLedgerRequestDto
+        List<BudgetRequestDto> budgetRequestDtos = createLedgerRequestDto
                 .getBudgets();
 
         validateLedgerPeriod(startDate, endDate, CustomerId.of(customerId));
 
-        validateBudgetCategories(createBudgetRequestDtos);
+        validateBudgetCategories(budgetRequestDtos);
 
         Ledger ledger = Ledger.builder()
                 .id(ulidGenerator.createRandomLedgerULID())
@@ -55,12 +55,12 @@ public class CreateLedgerService {
 
         ledgerRepository.save(ledger);
 
-        List<Budget> budgets = createBudgetRequestDtos.stream()
-                .map(createBudgetRequestDto -> Budget.builder()
+        List<Budget> budgets = budgetRequestDtos.stream()
+                .map(budgetRequestDto -> Budget.builder()
                         .id(ulidGenerator.createRandomBudgetULID())
                         .ledgerId(ledger.id())
-                        .category(createBudgetRequestDto.getCategory())
-                        .amount(createBudgetRequestDto.getAmount())
+                        .category(budgetRequestDto.getCategory())
+                        .amount(budgetRequestDto.getAmount())
                         .build())
                 .toList();
 
@@ -81,10 +81,10 @@ public class CreateLedgerService {
         }
     }
 
-    private void validateBudgetCategories(List<CreateBudgetRequestDto> createBudgetRequestDtos) {
+    private void validateBudgetCategories(List<BudgetRequestDto> budgetRequestDtos) {
         Set<String> categoryNames = new HashSet<>();
 
-        createBudgetRequestDtos.forEach(budget -> {
+        budgetRequestDtos.forEach(budget -> {
             String categoryName = budget.getCategory();
 
             if (!Category.contains(categoryName)) {

--- a/src/main/java/com/wanted/jaringoby/ledger/applications/ModifyLedgerBudgetsService.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/applications/ModifyLedgerBudgetsService.java
@@ -1,0 +1,131 @@
+package com.wanted.jaringoby.ledger.applications;
+
+import com.wanted.jaringoby.category.exceptions.CategoryDuplicatedException;
+import com.wanted.jaringoby.category.exceptions.CategoryNotFoundException;
+import com.wanted.jaringoby.category.models.Category;
+import com.wanted.jaringoby.common.models.Money;
+import com.wanted.jaringoby.common.utils.UlidGenerator;
+import com.wanted.jaringoby.customer.models.customer.CustomerId;
+import com.wanted.jaringoby.ledger.dtos.BudgetRequestDto;
+import com.wanted.jaringoby.ledger.dtos.ModifyLedgerBudgetsRequestDto;
+import com.wanted.jaringoby.ledger.exceptions.LedgerNotFoundException;
+import com.wanted.jaringoby.ledger.exceptions.LedgerNotOwnedException;
+import com.wanted.jaringoby.ledger.exceptions.LedgerPeriodEndedException;
+import com.wanted.jaringoby.ledger.models.budget.Budget;
+import com.wanted.jaringoby.ledger.models.ledger.Ledger;
+import com.wanted.jaringoby.ledger.models.ledger.LedgerId;
+import com.wanted.jaringoby.ledger.repositories.BudgetRepository;
+import com.wanted.jaringoby.ledger.repositories.LedgerRepository;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ModifyLedgerBudgetsService {
+
+    private final LedgerRepository ledgerRepository;
+    private final BudgetRepository budgetRepository;
+    private final UlidGenerator ulidGenerator;
+
+    @Transactional
+    public void modifyLedgerBudgets(
+            String customerId,
+            String ledgerId,
+            ModifyLedgerBudgetsRequestDto modifyLedgerBudgetsRequestDto
+    ) {
+        Ledger ledger = ledgerRepository.findById(LedgerId.of(ledgerId))
+                .orElseThrow(LedgerNotFoundException::new);
+
+        validateLedger(ledger, CustomerId.of(customerId));
+
+        List<BudgetRequestDto> budgetRequestDtos = modifyLedgerBudgetsRequestDto.getBudgets();
+
+        validateBudgetCategories(budgetRequestDtos);
+
+        List<Budget> budgets = budgetRepository.findByLedgerId(LedgerId.of(ledgerId));
+        List<Budget> newBudgets = new ArrayList<>();
+
+        budgetRequestDtos.forEach(budgetRequestDto -> {
+            Category category = Category.of(budgetRequestDto.getCategory());
+            Money amount = Money.of(budgetRequestDto.getAmount());
+
+            Budget modified = modifyBudgetIfCategoryExists(budgets, category, amount);
+
+            if (modified != null) {
+                budgets.remove(modified);
+                return;
+            }
+
+            Budget budget = Budget.builder()
+                    .id(ulidGenerator.createRandomBudgetULID())
+                    .ledgerId(ledger.id())
+                    .category(category)
+                    .amount(amount)
+                    .build();
+
+            newBudgets.add(budget);
+        });
+
+        if (budgetExists(newBudgets)) {
+            budgetRepository.saveAll(newBudgets);
+        }
+
+        List<Budget> notGivenBudgets = new ArrayList<>(budgets);
+
+        if (budgetExists(notGivenBudgets)) {
+            budgetRepository.deleteAll(budgets);
+        }
+    }
+
+    private void validateLedger(Ledger ledger, CustomerId customerId) {
+        if (!ledger.ownedBy(customerId)) {
+            throw new LedgerNotOwnedException();
+        }
+
+        if (ledger.hasEnded()) {
+            throw new LedgerPeriodEndedException();
+        }
+    }
+
+    private void validateBudgetCategories(List<BudgetRequestDto> budgetRequestDtos) {
+        Set<String> categoryNames = new HashSet<>();
+
+        budgetRequestDtos.forEach(budget -> {
+            String categoryName = budget.getCategory();
+
+            if (!Category.contains(categoryName)) {
+                throw new CategoryNotFoundException();
+            }
+
+            if (categoryNames.contains(categoryName)) {
+                throw new CategoryDuplicatedException();
+            }
+
+            categoryNames.add(categoryName);
+        });
+    }
+
+    private Budget modifyBudgetIfCategoryExists(
+            List<Budget> budgets,
+            Category category,
+            Money amount
+    ) {
+        for (Budget budget : budgets) {
+            if (budget.categoryEquals(category)) {
+                budget.modifyAmount(amount);
+                return budget;
+            }
+        }
+
+        return null;
+    }
+
+    private boolean budgetExists(List<Budget> budgets) {
+        return !budgets.isEmpty();
+    }
+}

--- a/src/main/java/com/wanted/jaringoby/ledger/applications/ModifyLedgerBudgetsService.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/applications/ModifyLedgerBudgetsService.java
@@ -78,7 +78,7 @@ public class ModifyLedgerBudgetsService {
         List<Budget> notGivenBudgets = new ArrayList<>(budgets);
 
         if (budgetExists(notGivenBudgets)) {
-            budgetRepository.deleteAll(budgets);
+            budgetRepository.deleteAll(notGivenBudgets);
         }
     }
 

--- a/src/main/java/com/wanted/jaringoby/ledger/controllers/LedgerController.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/controllers/LedgerController.java
@@ -5,10 +5,12 @@ import com.wanted.jaringoby.common.validations.BindingResultChecker;
 import com.wanted.jaringoby.common.validations.ValidationSequence;
 import com.wanted.jaringoby.ledger.applications.CreateLedgerService;
 import com.wanted.jaringoby.ledger.applications.GetOngoingLedgerService;
+import com.wanted.jaringoby.ledger.applications.ModifyLedgerBudgetsService;
 import com.wanted.jaringoby.ledger.applications.ModifyLedgerPeriodService;
 import com.wanted.jaringoby.ledger.dtos.CreateLedgerRequestDto;
 import com.wanted.jaringoby.ledger.dtos.CreateLedgerResponseDto;
 import com.wanted.jaringoby.ledger.dtos.GetLedgerDetailResponseDto;
+import com.wanted.jaringoby.ledger.dtos.ModifyLedgerBudgetsRequestDto;
 import com.wanted.jaringoby.ledger.dtos.ModifyLedgerPeriodRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -32,6 +34,7 @@ public class LedgerController {
     private final GetOngoingLedgerService getOngoingLedgerService;
     private final CreateLedgerService createLedgerService;
     private final ModifyLedgerPeriodService modifyLedgerPeriodService;
+    private final ModifyLedgerBudgetsService modifyLedgerBudgetsService;
     private final BindingResultChecker bindingResultChecker;
 
     @GetMapping("/now")
@@ -69,5 +72,20 @@ public class LedgerController {
 
         modifyLedgerPeriodService
                 .modifyLedgerPeriod(customerId, ledgerId, modifyLedgerPeriodRequestDto);
+    }
+
+    @PatchMapping("/{ledger-id}/budgets")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void modifyBudgets(
+            @RequestAttribute("customerId") String customerId,
+            @PathVariable("ledger-id") String ledgerId,
+            @Validated(ValidationSequence.class) @RequestBody
+            ModifyLedgerBudgetsRequestDto modifyLedgerBudgetsRequestDto,
+            BindingResult bindingResult
+    ) {
+        bindingResultChecker.checkBindingErrors(bindingResult);
+
+        modifyLedgerBudgetsService
+                .modifyLedgerBudgets(customerId, ledgerId, modifyLedgerBudgetsRequestDto);
     }
 }

--- a/src/main/java/com/wanted/jaringoby/ledger/dtos/BudgetRequestDto.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/dtos/BudgetRequestDto.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @Getter
-public class CreateBudgetRequestDto {
+public class BudgetRequestDto {
 
     @NotBlank(groups = MissingValueGroup.class)
     private String category;

--- a/src/main/java/com/wanted/jaringoby/ledger/dtos/CreateLedgerRequestDto.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/dtos/CreateLedgerRequestDto.java
@@ -26,5 +26,5 @@ public class CreateLedgerRequestDto {
 
     @Valid
     @NotEmpty(groups = MissingValueGroup.class)
-    private List<CreateBudgetRequestDto> budgets;
+    private List<BudgetRequestDto> budgets;
 }

--- a/src/main/java/com/wanted/jaringoby/ledger/dtos/ModifyLedgerBudgetsRequestDto.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/dtos/ModifyLedgerBudgetsRequestDto.java
@@ -1,0 +1,22 @@
+package com.wanted.jaringoby.ledger.dtos;
+
+import com.wanted.jaringoby.common.validations.groups.MissingValueGroup;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+@Getter
+public class ModifyLedgerBudgetsRequestDto {
+
+    @Valid
+    @NotEmpty(groups = MissingValueGroup.class)
+    private List<BudgetRequestDto> budgets;
+}

--- a/src/main/java/com/wanted/jaringoby/ledger/models/budget/Budget.java
+++ b/src/main/java/com/wanted/jaringoby/ledger/models/budget/Budget.java
@@ -52,13 +52,25 @@ public class Budget {
     public Budget(
             String id,
             LedgerId ledgerId,
-            String category,
-            Long amount
+            Category category,
+            Money amount
     ) {
         this.id = BudgetId.of(id);
         this.ledgerId = ledgerId;
-        this.category = Category.of(category);
-        this.amount = Money.of(amount);
+        this.category = category;
+        this.amount = amount;
+    }
+
+    public Category category() {
+        return category;
+    }
+
+    public boolean categoryEquals(Category category) {
+        return this.category.equals(category);
+    }
+
+    public void modifyAmount(Money amount) {
+        this.amount = amount;
     }
 
     public GetBudgetResponseDto toGetBudgetResponseDto() {

--- a/src/test/java/com/wanted/jaringoby/ledger/applications/CreateLedgerServiceTest.java
+++ b/src/test/java/com/wanted/jaringoby/ledger/applications/CreateLedgerServiceTest.java
@@ -14,7 +14,7 @@ import com.wanted.jaringoby.category.exceptions.CategoryNotFoundException;
 import com.wanted.jaringoby.category.models.Category;
 import com.wanted.jaringoby.common.utils.UlidGenerator;
 import com.wanted.jaringoby.customer.models.customer.CustomerId;
-import com.wanted.jaringoby.ledger.dtos.CreateBudgetRequestDto;
+import com.wanted.jaringoby.ledger.dtos.BudgetRequestDto;
 import com.wanted.jaringoby.ledger.dtos.CreateLedgerRequestDto;
 import com.wanted.jaringoby.ledger.dtos.CreateLedgerResponseDto;
 import com.wanted.jaringoby.ledger.exceptions.LedgerPeriodInvalidException;
@@ -77,7 +77,7 @@ class CreateLedgerServiceTest {
                     .startDate(START_DATE)
                     .endDate(END_DATE)
                     .budgets(List.of(
-                            CreateBudgetRequestDto.builder()
+                            BudgetRequestDto.builder()
                                     .category(Category.Leisure.categoryName())
                                     .amount(200_000L)
                                     .build()
@@ -109,7 +109,7 @@ class CreateLedgerServiceTest {
                     .startDate(START_DATE_BEFORE_NOW)
                     .endDate(END_DATE)
                     .budgets(List.of(
-                            CreateBudgetRequestDto.builder()
+                            BudgetRequestDto.builder()
                                     .category(Category.Leisure.categoryName())
                                     .amount(200_000L)
                                     .build()
@@ -130,7 +130,7 @@ class CreateLedgerServiceTest {
                     .startDate(START_DATE)
                     .endDate(END_DATE_BEFORE_START_DATE)
                     .budgets(List.of(
-                            CreateBudgetRequestDto.builder()
+                            BudgetRequestDto.builder()
                                     .category(Category.EtCetera.categoryName())
                                     .amount(200_000L)
                                     .build()
@@ -151,7 +151,7 @@ class CreateLedgerServiceTest {
                     .startDate(START_DATE)
                     .endDate(END_DATE)
                     .budgets(List.of(
-                            CreateBudgetRequestDto.builder()
+                            BudgetRequestDto.builder()
                                     .category(INVALID_CATEGORY_NAME)
                                     .amount(50_000_000L)
                                     .build()
@@ -172,11 +172,11 @@ class CreateLedgerServiceTest {
                     .startDate(START_DATE)
                     .endDate(END_DATE)
                     .budgets(List.of(
-                            CreateBudgetRequestDto.builder()
+                            BudgetRequestDto.builder()
                                     .category(Category.Leisure.categoryName())
                                     .amount(50_000_000L)
                                     .build(),
-                            CreateBudgetRequestDto.builder()
+                            BudgetRequestDto.builder()
                                     .category(Category.Leisure.categoryName())
                                     .amount(100_000_000L)
                                     .build()
@@ -201,7 +201,7 @@ class CreateLedgerServiceTest {
                     .startDate(START_DATE)
                     .endDate(END_DATE)
                     .budgets(List.of(
-                            CreateBudgetRequestDto.builder()
+                            BudgetRequestDto.builder()
                                     .category(Category.PersonalDevelopment.categoryName())
                                     .amount(100_000_000L)
                                     .build()

--- a/src/test/java/com/wanted/jaringoby/ledger/applications/GetOngoingLedgerServiceTest.java
+++ b/src/test/java/com/wanted/jaringoby/ledger/applications/GetOngoingLedgerServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.wanted.jaringoby.category.models.Category;
+import com.wanted.jaringoby.common.models.Money;
 import com.wanted.jaringoby.customer.models.customer.CustomerId;
 import com.wanted.jaringoby.ledger.dtos.GetLedgerDetailResponseDto;
 import com.wanted.jaringoby.ledger.exceptions.LedgerOngoingNotFound;
@@ -67,13 +68,13 @@ class GetOngoingLedgerServiceTest {
             List<Budget> budgets = List.of(
                     Budget.builder()
                             .id(BUDGET_ID_1)
-                            .category(Category.Living.categoryName())
-                            .amount(1_000_000L)
+                            .category(Category.of(Category.Living.categoryName()))
+                            .amount(Money.of(1_000_000L))
                             .build(),
                     Budget.builder()
                             .id(BUDGET_ID_2)
-                            .category(Category.Meal.categoryName())
-                            .amount(1_500_000L)
+                            .category(Category.of(Category.Meal.categoryName()))
+                            .amount(Money.of(1_500_000L))
                             .build()
             );
 

--- a/src/test/java/com/wanted/jaringoby/ledger/applications/ModifyLedgerBudgetsServiceTest.java
+++ b/src/test/java/com/wanted/jaringoby/ledger/applications/ModifyLedgerBudgetsServiceTest.java
@@ -1,0 +1,282 @@
+package com.wanted.jaringoby.ledger.applications;
+
+import static com.wanted.jaringoby.common.constants.Date.TODAY;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.wanted.jaringoby.category.exceptions.CategoryDuplicatedException;
+import com.wanted.jaringoby.category.exceptions.CategoryNotFoundException;
+import com.wanted.jaringoby.category.models.Category;
+import com.wanted.jaringoby.common.models.Money;
+import com.wanted.jaringoby.common.utils.UlidGenerator;
+import com.wanted.jaringoby.ledger.dtos.BudgetRequestDto;
+import com.wanted.jaringoby.ledger.dtos.ModifyLedgerBudgetsRequestDto;
+import com.wanted.jaringoby.ledger.exceptions.LedgerNotFoundException;
+import com.wanted.jaringoby.ledger.exceptions.LedgerNotOwnedException;
+import com.wanted.jaringoby.ledger.exceptions.LedgerPeriodEndedException;
+import com.wanted.jaringoby.ledger.models.budget.Budget;
+import com.wanted.jaringoby.ledger.models.ledger.Ledger;
+import com.wanted.jaringoby.ledger.models.ledger.LedgerId;
+import com.wanted.jaringoby.ledger.repositories.BudgetRepository;
+import com.wanted.jaringoby.ledger.repositories.LedgerRepository;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ModifyLedgerBudgetsServiceTest {
+
+    private ModifyLedgerBudgetsService modifyLedgerBudgetsService;
+    private LedgerRepository ledgerRepository;
+    private BudgetRepository budgetRepository;
+    private UlidGenerator ulidGenerator;
+
+    @BeforeEach
+    void setUp() {
+        ledgerRepository = mock(LedgerRepository.class);
+        budgetRepository = mock(BudgetRepository.class);
+        ulidGenerator = spy(new UlidGenerator());
+        modifyLedgerBudgetsService = new ModifyLedgerBudgetsService(
+                ledgerRepository,
+                budgetRepository,
+                ulidGenerator
+        );
+    }
+
+    private static final String CUSTOMER_ID = "CUSTOMER_ID";
+    private static final String LEDGER_ID = "LEDGER_ID";
+
+    private static final LocalDate START_DATE = TODAY;
+    private static final LocalDate END_DATE = TODAY.plusWeeks(2);
+
+    private ModifyLedgerBudgetsRequestDto modifyLedgerBudgetsRequestDto;
+
+    @DisplayName("성공")
+    @Nested
+    class Success {
+
+        private Budget existingAndGivenBudget1;
+        private Budget existingButNotGivenBudget2;
+
+        @BeforeEach
+        void setUp() {
+            Ledger ledger = Ledger.builder()
+                    .id(LEDGER_ID)
+                    .customerId(CUSTOMER_ID)
+                    .startDate(START_DATE)
+                    .endDate(END_DATE)
+                    .build();
+
+            given(ledgerRepository.findById(LedgerId.of(LEDGER_ID)))
+                    .willReturn(Optional.of(ledger));
+
+            existingAndGivenBudget1 = spy(Budget.builder()
+                    .category(Category.Meal)
+                    .amount(Money.of(1_000_000L))
+                    .build()
+            );
+            existingButNotGivenBudget2 = spy(Budget.builder()
+                    .category(Category.Transportation)
+                    .amount(Money.of(200_000L))
+                    .build()
+            );
+
+            given(budgetRepository.findByLedgerId(LedgerId.of(LEDGER_ID)))
+                    .willReturn(new ArrayList<>(List.of(
+                            existingAndGivenBudget1,
+                            existingButNotGivenBudget2
+                    )));
+
+            modifyLedgerBudgetsRequestDto = ModifyLedgerBudgetsRequestDto.builder()
+                    .budgets(List.of(
+                            BudgetRequestDto.builder()
+                                    .category(Category.Meal.categoryName())
+                                    .amount(10_000L)
+                                    .build(),
+                            BudgetRequestDto.builder()
+                                    .category(Category.Leisure.categoryName())
+                                    .amount(100_000L)
+                                    .build()
+                    ))
+                    .build();
+        }
+
+        @DisplayName("전달된 예산들 중 존재하는 카테고리의 예산은 수정")
+        @Test
+        void modifyBudgetsIfCategoryExists() {
+            assertDoesNotThrow(() -> modifyLedgerBudgetsService
+                    .modifyLedgerBudgets(CUSTOMER_ID, LEDGER_ID, modifyLedgerBudgetsRequestDto));
+
+            verify(existingAndGivenBudget1).modifyAmount(any(Money.class));
+        }
+
+        @DisplayName("전달된 예산들 중 존재하지 않는 카테고리의 예산은 새로 생성")
+        @Test
+        void saveNewBudgets() {
+            assertDoesNotThrow(() -> modifyLedgerBudgetsService
+                    .modifyLedgerBudgets(CUSTOMER_ID, LEDGER_ID, modifyLedgerBudgetsRequestDto));
+
+            verify(ulidGenerator, times(1)).createRandomBudgetULID();
+            verify(budgetRepository).saveAll(any());
+        }
+
+        @DisplayName("존재하는 카테고리의 예산이 전달되지 않은 경우 삭제")
+        @Test
+        void deleteNotGivenBudgets() {
+            assertDoesNotThrow(() -> modifyLedgerBudgetsService
+                    .modifyLedgerBudgets(CUSTOMER_ID, LEDGER_ID, modifyLedgerBudgetsRequestDto));
+
+            verify(existingButNotGivenBudget2, never()).modifyAmount(any(Money.class));
+            verify(budgetRepository).deleteAll(any());
+        }
+    }
+
+    @DisplayName("실패")
+    @Nested
+    class Failure {
+
+        private static final String OTHER_CUSTOMER_ID = "OTHER_CUSTOMER_ID";
+        private static final String NOT_EXISTING_CATEGORY = "NOT_EXISTING_CATEGORY";
+
+        private static final LocalDate ENDED_START_DATE = TODAY.minusWeeks(2);
+        private static final LocalDate ENDED_END_DATE = TODAY.minusWeeks(1);
+
+        @DisplayName("존재하지 않는 예산 관리인 경우 예외처리")
+        @Test
+        void ledgerNotFound() {
+            given(ledgerRepository.findById(LedgerId.of(LEDGER_ID)))
+                    .willThrow(LedgerNotFoundException.class);
+
+            modifyLedgerBudgetsRequestDto = ModifyLedgerBudgetsRequestDto.builder()
+                    .budgets(List.of(
+                            BudgetRequestDto.builder()
+                                    .category(Category.Meal.categoryName())
+                                    .amount(10_000L)
+                                    .build()
+                    ))
+                    .build();
+
+            assertThrows(LedgerNotFoundException.class, () -> modifyLedgerBudgetsService
+                    .modifyLedgerBudgets(CUSTOMER_ID, LEDGER_ID, modifyLedgerBudgetsRequestDto));
+        }
+
+        @DisplayName("대상 고객의 예산 관리가 아닌 경우 예외처리")
+        @Test
+        void ledgerNotOwned() {
+            Ledger ledger = Ledger.builder()
+                    .id(LEDGER_ID)
+                    .customerId(OTHER_CUSTOMER_ID)
+                    .startDate(START_DATE)
+                    .endDate(END_DATE)
+                    .build();
+
+            given(ledgerRepository.findById(LedgerId.of(LEDGER_ID)))
+                    .willReturn(Optional.of(ledger));
+
+            modifyLedgerBudgetsRequestDto = ModifyLedgerBudgetsRequestDto.builder()
+                    .budgets(List.of(
+                            BudgetRequestDto.builder()
+                                    .category(Category.Meal.categoryName())
+                                    .amount(10_000L)
+                                    .build()
+                    ))
+                    .build();
+
+            assertThrows(LedgerNotOwnedException.class, () -> modifyLedgerBudgetsService
+                    .modifyLedgerBudgets(CUSTOMER_ID, LEDGER_ID, modifyLedgerBudgetsRequestDto));
+        }
+
+        @DisplayName("종료된 예산 관리인 경우 예외처리")
+        @Test
+        void ledgerPeriodEnded() {
+            Ledger ledger = Ledger.builder()
+                    .id(LEDGER_ID)
+                    .customerId(CUSTOMER_ID)
+                    .startDate(ENDED_START_DATE)
+                    .endDate(ENDED_END_DATE)
+                    .build();
+
+            given(ledgerRepository.findById(LedgerId.of(LEDGER_ID)))
+                    .willReturn(Optional.of(ledger));
+
+            modifyLedgerBudgetsRequestDto = ModifyLedgerBudgetsRequestDto.builder()
+                    .budgets(List.of(
+                            BudgetRequestDto.builder()
+                                    .category(NOT_EXISTING_CATEGORY)
+                                    .amount(10_000L)
+                                    .build()
+                    ))
+                    .build();
+
+            assertThrows(LedgerPeriodEndedException.class, () -> modifyLedgerBudgetsService
+                    .modifyLedgerBudgets(CUSTOMER_ID, LEDGER_ID, modifyLedgerBudgetsRequestDto));
+        }
+
+        @DisplayName("존재하지 않는 카테고리인 경우 예외처리")
+        @Test
+        void categoryNotFound() {
+            Ledger ledger = Ledger.builder()
+                    .id(LEDGER_ID)
+                    .customerId(CUSTOMER_ID)
+                    .startDate(START_DATE)
+                    .endDate(END_DATE)
+                    .build();
+
+            given(ledgerRepository.findById(LedgerId.of(LEDGER_ID)))
+                    .willReturn(Optional.of(ledger));
+
+            modifyLedgerBudgetsRequestDto = ModifyLedgerBudgetsRequestDto.builder()
+                    .budgets(List.of(
+                            BudgetRequestDto.builder()
+                                    .category(NOT_EXISTING_CATEGORY)
+                                    .amount(10_000L)
+                                    .build()
+                    ))
+                    .build();
+
+            assertThrows(CategoryNotFoundException.class, () -> modifyLedgerBudgetsService
+                    .modifyLedgerBudgets(CUSTOMER_ID, LEDGER_ID, modifyLedgerBudgetsRequestDto));
+        }
+
+        @DisplayName("카테고리가 중복해서 주어지는 경우 예외처리")
+        @Test
+        void categoryDuplicated() {
+            Ledger ledger = Ledger.builder()
+                    .id(LEDGER_ID)
+                    .customerId(CUSTOMER_ID)
+                    .startDate(START_DATE)
+                    .endDate(END_DATE)
+                    .build();
+
+            given(ledgerRepository.findById(LedgerId.of(LEDGER_ID)))
+                    .willReturn(Optional.of(ledger));
+
+            modifyLedgerBudgetsRequestDto = ModifyLedgerBudgetsRequestDto.builder()
+                    .budgets(List.of(
+                            BudgetRequestDto.builder()
+                                    .category(Category.Meal.categoryName())
+                                    .amount(10_000L)
+                                    .build(),
+                            BudgetRequestDto.builder()
+                                    .category(Category.Meal.categoryName())
+                                    .amount(500_000L)
+                                    .build()
+                    ))
+                    .build();
+
+            assertThrows(CategoryDuplicatedException.class, () -> modifyLedgerBudgetsService
+                    .modifyLedgerBudgets(CUSTOMER_ID, LEDGER_ID, modifyLedgerBudgetsRequestDto));
+        }
+    }
+}


### PR DESCRIPTION
## 💻 작업 내역

- 특정 예산 관리에 배정된 예산들을 추가/수정/삭제하는 API 구현.

### 비즈니스 로직

- 대상 고객 식별자, 대상 예산 관리 식별자, 예산 목록을 인자로 전달
- 다음의 경우 예외처리
  - 미입력 데이터 존재
  - 1개 미만의 budget을 입력
  - 존재하지 않는 카테고리
  - 특정 카테고리에 대해 1원 미만의 예산 배정
  - 대상 예산 관리 미존재
  - 다른 고객의 예산 관리
  - 종료된 예산 관리
- 전달된 예산에 대해 다음을 수행
  - 특정 예산 관리에 대해 해당 카테고리인 예산이 존재하지 않는 경우, 새로 생성 후 저장
  - 특정 예산 관리에 대해 해당 카테고리인 예산이 존재하는 경우, 수정
  - 특정 예산 관리의 카테고리에 대해 예산이 전달되지 않은 경우, 해당 예산은 삭제

## 🔎 PR 특이 사항

### `BudgetRequestDto`

- `CreateBudgetRequestDto`를 `CreateLedgerRequestDto`와 `ModifyLedgerBudgetsRequestDto`에서 공통으로 사용할 수 있어 공통 DTO로 적용