### PR TITLE
🪲 BugFix: 예산 추천 - 추천 예산 절사 총액이 입력된 총액을 초과하는 이슈 수정

### DIFF
--- a/src/main/java/com/wanted/jaringoby/common/models/Money.java
+++ b/src/main/java/com/wanted/jaringoby/common/models/Money.java
@@ -55,4 +55,9 @@ public class Money {
                 : amount - remainder;
         return Money.of(truncatedAmount);
     }
+
+    public Money floor(Long truncationScale) {
+        Long remainder = amount % truncationScale;
+        return Money.of(amount - remainder);
+    }
 }

--- a/src/main/java/com/wanted/jaringoby/domains/ledger/models/BudgetAmountTruncator.java
+++ b/src/main/java/com/wanted/jaringoby/domains/ledger/models/BudgetAmountTruncator.java
@@ -38,7 +38,9 @@ public class BudgetAmountTruncator {
 
             Category category = biggestCategoryAndMoney.getKey();
             Money biggestMoney = biggestCategoryAndMoney.getValue();
-            Money adjusted = biggestMoney.subtract(Money.of(truncationScale));
+            Money excess = truncatedAmountSum.subtract(totalAmount);
+            Money adjusted = biggestMoney.subtract(excess)
+                    .floor(truncationScale);
 
             categoriesAndTruncatedAmounts.put(category, adjusted);
         }

--- a/src/test/java/com/wanted/jaringoby/common/models/MoneyTest.java
+++ b/src/test/java/com/wanted/jaringoby/common/models/MoneyTest.java
@@ -70,4 +70,12 @@ class MoneyTest {
             assertThat(money.truncate(truncationScale)).isEqualTo(Money.of(1_132_000L));
         }
     }
+
+    @DisplayName("floor")
+    @Test
+    void floor() {
+        Money money = Money.of(311_835L);
+        Long truncationScale = 1_000L;
+        assertThat(money.floor(truncationScale)).isEqualTo(Money.of(311_000L));
+    }
 }

--- a/src/test/java/com/wanted/jaringoby/domains/ledger/models/BudgetAmountTruncatorTest.java
+++ b/src/test/java/com/wanted/jaringoby/domains/ledger/models/BudgetAmountTruncatorTest.java
@@ -24,48 +24,86 @@ class BudgetAmountTruncatorTest {
     class Truncate {
 
         @DisplayName("주어진 절사 단위에 맞게 금액을 반올림하거나 반내림")
-        @Test
-        void truncate() {
-            Money mealAmount = Money.of(1_131_247L);
-            Money transportationAmount = Money.of(866_235L);
-            Money leisureAmount = Money.of(42_235L);
-            Money livingAmount = Money.of(310_497L);
-            Money etCeteraAmount = Money.of(7_630L);
+        @Nested
+        class Cases {
 
-            Map<Category, Money> categoriesAndAmounts = Map.of(
-                Category.Meal, mealAmount,
-                Category.Transportation, transportationAmount,
-                Category.Leisure, leisureAmount,
-                Category.Living, livingAmount,
-                Category.EtCetera, etCeteraAmount
-            );
-            Long truncationScale = 1_000L;
-            Money totalAmount = mealAmount.add(transportationAmount)
-                    .add(leisureAmount)
-                    .add(livingAmount)
-                    .add(etCeteraAmount);
+            @DisplayName("케이스 1")
+            @Test
+            void case1() {
+                Money mealAmount = Money.of(1_131_247L);
+                Money transportationAmount = Money.of(866_235L);
+                Money leisureAmount = Money.of(42_235L);
+                Money livingAmount = Money.of(310_497L);
+                Money etCeteraAmount = Money.of(7_630L);
 
-            Map<Category, Money> categoriesAndTruncatedAmounts = budgetAmountTruncator
-                    .truncate(categoriesAndAmounts, truncationScale, totalAmount);
+                Map<Category, Money> categoriesAndAmounts = Map.of(
+                        Category.Meal, mealAmount,
+                        Category.Transportation, transportationAmount,
+                        Category.Leisure, leisureAmount,
+                        Category.Living, livingAmount,
+                        Category.EtCetera, etCeteraAmount
+                );
+                Long truncationScale = 1_000L;
+                Money totalAmount = mealAmount.add(transportationAmount)
+                        .add(leisureAmount)
+                        .add(livingAmount)
+                        .add(etCeteraAmount);
 
-            assertThat(categoriesAndTruncatedAmounts).containsKeys(
-                    Category.Meal,
-                    Category.Transportation,
-                    Category.Leisure,
-                    Category.Living,
-                    Category.EtCetera
-            );
+                Map<Category, Money> categoriesAndTruncatedAmounts = budgetAmountTruncator
+                        .truncate(categoriesAndAmounts, truncationScale, totalAmount);
 
-            assertThat(categoriesAndTruncatedAmounts.get(Category.Meal))
-                    .isEqualTo(Money.of(1_131_000L));
-            assertThat(categoriesAndTruncatedAmounts.get(Category.Transportation))
-                    .isEqualTo(Money.of(866_000L));
-            assertThat(categoriesAndTruncatedAmounts.get(Category.Leisure))
-                    .isEqualTo(Money.of(42_000L));
-            assertThat(categoriesAndTruncatedAmounts.get(Category.Living))
-                    .isEqualTo(Money.of(310_000L));
-            assertThat(categoriesAndTruncatedAmounts.get(Category.EtCetera))
-                    .isEqualTo(Money.of(8_000L));
+                assertThat(categoriesAndTruncatedAmounts).containsKeys(
+                        Category.Meal,
+                        Category.Transportation,
+                        Category.Leisure,
+                        Category.Living,
+                        Category.EtCetera
+                );
+
+                assertThat(categoriesAndTruncatedAmounts.get(Category.Meal))
+                        .isEqualTo(Money.of(1_131_000L));
+                assertThat(categoriesAndTruncatedAmounts.get(Category.Transportation))
+                        .isEqualTo(Money.of(866_000L));
+                assertThat(categoriesAndTruncatedAmounts.get(Category.Leisure))
+                        .isEqualTo(Money.of(42_000L));
+                assertThat(categoriesAndTruncatedAmounts.get(Category.Living))
+                        .isEqualTo(Money.of(310_000L));
+                assertThat(categoriesAndTruncatedAmounts.get(Category.EtCetera))
+                        .isEqualTo(Money.of(8_000L));
+            }
+
+            @DisplayName("케이스 2")
+            @Test
+            void case2() {
+                Money mealAmount = Money.of(999_500L);
+                Money transportationAmount = Money.of(999_500L);
+                Money leisureAmount = Money.of(999_500L);
+                Money livingAmount = Money.of(999_500L);
+                Money etCeteraAmount = Money.of(999_500L);
+
+                Map<Category, Money> categoriesAndAmounts = Map.of(
+                        Category.Meal, mealAmount,
+                        Category.Transportation, transportationAmount,
+                        Category.Leisure, leisureAmount,
+                        Category.Living, livingAmount,
+                        Category.EtCetera, etCeteraAmount
+                );
+                Long truncationScale = 1_000L;
+                Money totalAmount = mealAmount.add(transportationAmount)
+                        .add(leisureAmount)
+                        .add(livingAmount)
+                        .add(etCeteraAmount);
+
+                Map<Category, Money> categoriesAndTruncatedAmounts = budgetAmountTruncator
+                        .truncate(categoriesAndAmounts, truncationScale, totalAmount);
+
+                Money truncatedAmountSum = categoriesAndTruncatedAmounts.values()
+                        .stream()
+                        .reduce(Money::add)
+                        .get();
+
+                assertThat(truncatedAmountSum).isEqualTo(Money.of(4_997_000L));
+            }
         }
 
         @DisplayName("절사 후 금액 합계가 총액보다 작거나 같은 경우")


### PR DESCRIPTION
## 💻 작업 내역

- 추천 예산 절사 총액이 절사 단위보다 크게 입력된 총액을 초과하는 경우에 절사 단위만큼을 감산하면 여전히 절사 총액이 입력된 총액을 초과하는 문제 발생
- 초과액만큼을 가장 액수가 높은 예산 추천액에서 감산한 뒤, 해당 금액을 절사 단위만큼 반내림하는 것으로 절사 총액이 입력된 총액을 초과하는 이슈 방지